### PR TITLE
:sparkles: Default UI tests to off, enable them for nightlies

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -29,7 +29,8 @@ on:
           A flag that determines whether the UI tests should be run or not
         type: boolean
         required: false
-        default: true
+        # TODO: Swap to true once these are passing consistently
+        default: false
       api_tests_ref:
         description: |
           The branch or PR of the go-konveyor-tests repository to clone.
@@ -82,7 +83,8 @@ on:
           A flag that determines whether the UI tests should be run or not
         type: boolean
         required: false
-        default: true
+        # TODO: Swap to true once these are passing consistently
+        default: false
       api_tests_ref:
         description: |
           The branch or PR of the go-konveyor-tests repository to clone.
@@ -178,8 +180,7 @@ jobs:
         working-directory: go-konveyor-tests
 
   e2e-ui-integration-tests:
-    # TODO once these are passing consistently within about an hour reenable for PRs
-    if: ${{ github.event_name != 'pull_request' && inputs.run_ui_tests }}
+    if: ${{ inputs.run_ui_tests }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-main.yaml
+++ b/.github/workflows/nightly-main.yaml
@@ -12,3 +12,4 @@ jobs:
       tag: latest
       api_tests_ref: main
       ui_tests_ref: main
+      run_ui_tests: true

--- a/.github/workflows/nightly-release-0.1.yaml
+++ b/.github/workflows/nightly-release-0.1.yaml
@@ -12,3 +12,4 @@ jobs:
       tag: release-0.1
       api_tests_ref: 95c17ea090d50c0c623aa7d43168f6ca8fe26a88
       ui_tests_ref: mta_6.1.1
+      run_ui_tests: true

--- a/.github/workflows/nightly-release-0.2.yaml
+++ b/.github/workflows/nightly-release-0.2.yaml
@@ -13,3 +13,4 @@ jobs:
       api_tests_ref: 95c17ea090d50c0c623aa7d43168f6ca8fe26a88
       # TODO: this needs to be pinned to a release-0.2 specific branch
       ui_tests_ref: main
+      run_ui_tests: true


### PR DESCRIPTION
Currently this will fail the push tests for any repo that imports these, which is definitely not what we want. Swapping the flag to false for now and once they're stable we can reenable them. Leaving them on for the nightlies.

Example failure: https://github.com/konveyor/analyzer-lsp/actions/runs/5259839312