### PR TITLE
Update API tests to use tier0 test suite

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Build and run golang API tests
         run: |
           export HUB_BASE_URL="http://$(minikube ip)/hub"
-          go test -v ./analysis/...
+          make test-tier0
         working-directory: go-konveyor-tests
 
   e2e-ui-integration-tests:


### PR DESCRIPTION
API tests repo konveyor/go-konveyor-tests introduced tests in tiers (from core critical functionality to more fragile and complicated tests). Updating workflows to execute tier0 tests as part of global CI.

Next steps would be to execute also tier1 and tier2 tests (both currently broken anyway).