### PR TITLE
Update memory for api analysis

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -145,6 +145,8 @@ jobs:
 
       - name: start minikube
         uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        with:
+          memory: 6500M
 
       # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image


### PR DESCRIPTION
This is bit dirty (going to edge of memory limits), but currently works in go-konveyor-tests repo.