### PR TITLE
Add Hub API Tests Ref input to CI workflow

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -43,6 +43,14 @@ on:
         required: false
         type: string
         default: main
+      api_hub_tests_ref:
+          description: |
+            The branch or PR of the Hub API tests from tackle2-hub repository to clone.
+            For a pull request, the reference format would be "refs/pull/${PR_NUMBER}/merge".
+            For a branch, the reference format would just be the branch name.
+          required: false
+          type: string
+          default: main
       ui_tests_ref:
         description: |
           The branch or PR of the tackle-ui-tests repository to clone.
@@ -97,6 +105,14 @@ on:
         required: false
         type: string
         default: main
+      api_hub_tests_ref:
+          description: |
+            The branch or PR of the Hub API tests from tackle2-hub repository to clone.
+            For a pull request, the reference format would be "refs/pull/${PR_NUMBER}/merge".
+            For a branch, the reference format would just be the branch name.
+          required: false
+          type: string
+          default: main
       ui_tests_ref:
         description: |
           The branch or PR of the tackle-ui-tests repository to clone.
@@ -182,6 +198,7 @@ jobs:
       - name: Build and run golang API tests
         run: |
           export HUB_BASE_URL="http://$(minikube ip)/hub"
+          export HUB_TESTS_REF="${{ inputs.api_hub_tests_ref }}"
           make test-tier0 test-tier1
         working-directory: go-konveyor-tests
 


### PR DESCRIPTION
Adding api_hub_tests_ref Github workflow input, that sets HUB_TESTS_REF environment variable in go-konveyor-tests exection.

This variable is used to run Hub API tests directly from branch of the given Hub PR.

Related to https://github.com/konveyor/ci/issues/22