### PR TITLE
:seedling: Fix global-ci workflow parsing for test refs

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -173,16 +173,19 @@ jobs:
     if: ${{ inputs.run_api_tests }}
     steps:
       - name: Extract pull request number from inputs or PR description
+        env:
+          body: ${{ github.event.pull_request.body }}
         run: |
-          PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[A|a][P|p][I|i] [T|t]ests [P|p][R|r]: \K\d+' || true)
-          if [ -z "$PULL_REQUEST_NUMBER" ]; then
-            echo "GOLANG_TESTS_REF=${{ inputs.api_tests_ref }}" >>$GITHUB_ENV
-          else
-            echo "GOLANG_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge" >>$GITHUB_ENV
-          fi
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[A|a][P|p][I|i] [T|t]ests [P|p][R|r]:\s*\K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && GOLANG_TESTS_REF=${{ inputs.api_tests_ref }} \
+            || GOLANG_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "GOLANG_TESTS_REF=${GOLANG_TESTS_REF}" >>"$GITHUB_ENV"
+          echo "Using GOLANG_TESTS_REF \`${GOLANG_TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Checkout golang api tests repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: konveyor/go-konveyor-tests
           path: go-konveyor-tests
@@ -262,19 +265,22 @@ jobs:
         # TODO: Support cypress-split in main tackle-ui-test project
         # split: [0, 1, 2, 3, 4, 5, 6, 7, 8]
         tier: [tier1, tier2, tier3]
-    steps:
 
+    steps:
       - name: Extract pull request number from inputs or PR description
+        env:
+          body: ${{ github.event.pull_request.body }}
         run: |
-          PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[U|u][I|i] [T|t]ests [P|p][R|r]: \K\d+' || true)
-          if [ -z "$PULL_REQUEST_NUMBER" ]; then
-            echo "UI_TESTS_REF=${{ inputs.ui_tests_ref }}" >>$GITHUB_ENV
-          else
-            echo "UI_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge" >>$GITHUB_ENV
-          fi
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[U|u][I|i] [T|t]ests [P|p][R|r]: \K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && UI_TESTS_REF=${{ inputs.ui_tests_ref }} \
+            || UI_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "UI_TESTS_REF=${UI_TESTS_REF}" >>"$GITHUB_ENV"
+          echo "Using UI_TESTS_REF \`${UI_TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Checkout ui tests repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: konveyor/tackle-ui-tests
           path: tackle-ui-tests
@@ -376,7 +382,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          # name: tackle-ui-test-reports-${{ matrix.split }}
           name: tackle-ui-test-reports-${{ matrix.tier }}
           path: |
             tackle-ui-tests/cypress/reports

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -130,16 +130,19 @@ jobs:
     if: ${{ inputs.run_api_tests }}
     steps:
       - name: Extract pull request number from inputs or PR description
+        env:
+          body: ${{ github.event.pull_request.body }}
         run: |
-          PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[A|a][P|p][I|i] [T|t]ests [P|p][R|r]:\s*\K\d+' || true)
-          if [ -z "$PULL_REQUEST_NUMBER" ]; then
-            echo "GOLANG_TESTS_REF=${{ inputs.api_tests_ref }}" >>$GITHUB_ENV
-          else
-            echo "GOLANG_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge" >>$GITHUB_ENV
-          fi
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[A|a][P|p][I|i] [T|t]ests [P|p][R|r]:\s*\K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && GOLANG_TESTS_REF=${{ inputs.api_tests_ref }} \
+            || GOLANG_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "GOLANG_TESTS_REF=${GOLANG_TESTS_REF}" >>"$GITHUB_ENV"
+          echo "Using GOLANG_TESTS_REF \`${GOLANG_TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Checkout golang api tests repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: konveyor/go-konveyor-tests
           path: go-konveyor-tests
@@ -175,7 +178,6 @@ jobs:
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
-          pathfinder-image: "quay.io/konveyor/tackle-pathfinder:${{ inputs.tag != 'latest' && inputs.tag || '1.3.0-native' }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
           image-pull-policy: IfNotPresent
@@ -207,19 +209,22 @@ jobs:
       matrix:
         # TODO enable customizing the number of tiers run for nightlies
         tier: [tier0] #, tier1, tier2, tier3]
-    steps:
 
+    steps:
       - name: Extract pull request number from inputs or PR description
+        env:
+          body: ${{ github.event.pull_request.body }}
         run: |
-          PULL_REQUEST_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oP '[U|u][I|i] [T|t]ests [P|p][R|r]: \K\d+' || true)
-          if [ -z "$PULL_REQUEST_NUMBER" ]; then
-            echo "UI_TESTS_REF=${{ inputs.ui_tests_ref }}" >>$GITHUB_ENV
-          else
-            echo "UI_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge" >>$GITHUB_ENV
-          fi
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[U|u][I|i] [T|t]ests [P|p][R|r]: \K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && UI_TESTS_REF=${{ inputs.ui_tests_ref }} \
+            || UI_TESTS_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "UI_TESTS_REF=${UI_TESTS_REF}" >>"$GITHUB_ENV"
+          echo "Using UI_TESTS_REF \`${UI_TESTS_REF}\`" >>"$GITHUB_STEP_SUMMARY"
 
       - name: Checkout ui tests repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: konveyor/tackle-ui-tests
           path: tackle-ui-tests
@@ -253,7 +258,6 @@ jobs:
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
-          pathfinder-image: "quay.io/konveyor/tackle-pathfinder:${{ inputs.tag != 'latest' && inputs.tag || '1.3.0-native' }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
           image-pull-policy: IfNotPresent
@@ -304,7 +308,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          # name: tackle-ui-test-reports-${{ matrix.split }}
           name: tackle-ui-test-reports-${{ matrix.tier }}
           path: |
             tackle-ui-tests/cypress/reports


### PR DESCRIPTION
Resolves: #31

  - Pass the github event PR description via a step env variable to avoid any string interpolation problems.

  - Report the calculated test ref (`GOLANG_TESTS_REF` and `UI_TESTS_REF`) via step summary so it is easy to see in the action summary page.

  - Drop `pathfinder-image` input from the `install-tackle` action since that input has been removed.

  - Bump `actions/checkout` to `@v4` to fix its deprecated warning.
