### PR TITLE
:seedling: For repo CI, cancel in progress CI actions if a PR or branch is updated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: Konveyor CI
 
 on: ["push", "pull_request"]
 
+concurrency:
+  group: Konveyor-CI-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/global-ci.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Run Konveyor main branch tests
 
 on: ["push", "pull_request"]
 
+concurrency:
+  group: Konveyor-main-branch-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     uses: ./.github/workflows/global-ci.yml
@@ -10,5 +14,4 @@ jobs:
       api_tests_ref: main
       run_api_tests: true
       ui_tests_ref: main
-      # Disabled while we wait for stability
       run_ui_tests: true


### PR DESCRIPTION
If a PR or a branch is updated when the `ci.yaml` or `main.yml` workflow is running, cancel the old runs.  Finishing the old runs is not necessary.