### PR TITLE
Report nightly release-0.3 CI failure

### DIFF
--- a/.github/workflows/nightly-release-0.3.yaml
+++ b/.github/workflows/nightly-release-0.3.yaml
@@ -16,3 +16,20 @@ jobs:
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
+  report_failure:
+    needs: release-0_3-nightly
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "test": "E2E API",
+              "branch": "release-0.3",
+              "note": "Failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This should trigger slack workflow that sends message and emails to relevant channel when nightly tests fail on release-0.3 branch.

Starting with release-0.3