### PR TITLE
Update global-ci allowing set operator branch

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -14,13 +14,6 @@ on:
         type: string
         required: false
         default: ""
-      operator_branch:
-        description: |
-          The branch name for operator to be used for setup, e.g. a build for release-0.2,
-          you would specify "release-0.2".
-        required: false
-        type: string
-        default: main
       oauth_proxy:
         description: image uri for oauth_proxy (ie. quay.io/<namespace>/<image-name>:<tag>)
         type: string
@@ -112,13 +105,6 @@ on:
         type: string
         required: false
         default: ""
-      operator_branch:
-        description: |
-          The branch name for operator to be used for setup, e.g. a build for release-0.2,
-          you would specify "release-0.2".
-        required: false
-        type: string
-        default: main
       tackle_hub:
         description: image uri for tackle-hub (ie. quay.io/<namespace>/<image-name>:<tag>)
         type: string
@@ -218,7 +204,7 @@ jobs:
           path: /tmp/images
 
       - name: Start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
         with:
           memory: 6500M
 
@@ -232,7 +218,7 @@ jobs:
           ; done
 
       - name: Make bundle
-        uses: konveyor/tackle2-operator/.github/actions/make-bundle@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
         with:
           operator_bundle: ${{ env.operator_bundle }}
           operator: ${{ inputs.operator }}
@@ -248,7 +234,7 @@ jobs:
         run: docker push ${operator_bundle}
 
       - name: Install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@main
         with:
           bundle_image: ${{ env.operator_bundle }}
           namespace: ${{ inputs.namespace }}
@@ -313,7 +299,7 @@ jobs:
           path: /tmp/images
 
       - name: Start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
         with:
           memory: 6500M
 
@@ -327,7 +313,7 @@ jobs:
           ; done
 
       - name: Make bundle
-        uses: konveyor/tackle2-operator/.github/actions/make-bundle@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
         with:
           operator_bundle: ${{ env.operator_bundle }}
           operator: ${{ inputs.operator }}
@@ -343,7 +329,7 @@ jobs:
         run: docker push ${operator_bundle}
 
       - name: Install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@${{ inputs.operator_branch }}
+        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@main
         with:
           bundle_image: ${{ env.operator_bundle }}
           namespace: ${{ inputs.namespace }}

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -14,6 +14,13 @@ on:
         type: string
         required: false
         default: ""
+      operator_branch:
+        description: |
+          The branch name for operator to be used for setup, e.g. a build for release-0.2,
+          you would specify "release-0.2".
+        required: false
+        type: string
+        default: main
       oauth_proxy:
         description: image uri for oauth_proxy (ie. quay.io/<namespace>/<image-name>:<tag>)
         type: string
@@ -105,6 +112,13 @@ on:
         type: string
         required: false
         default: ""
+      operator_branch:
+        description: |
+          The branch name for operator to be used for setup, e.g. a build for release-0.2,
+          you would specify "release-0.2".
+        required: false
+        type: string
+        default: main
       tackle_hub:
         description: image uri for tackle-hub (ie. quay.io/<namespace>/<image-name>:<tag>)
         type: string
@@ -204,7 +218,7 @@ jobs:
           path: /tmp/images
 
       - name: Start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
         with:
           memory: 6500M
 
@@ -218,7 +232,7 @@ jobs:
           ; done
 
       - name: Make bundle
-        uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
+        uses: konveyor/tackle2-operator/.github/actions/make-bundle@${{ inputs.operator_branch }}
         with:
           operator_bundle: ${{ env.operator_bundle }}
           operator: ${{ inputs.operator }}
@@ -234,7 +248,7 @@ jobs:
         run: docker push ${operator_bundle}
 
       - name: Install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@main
+        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@${{ inputs.operator_branch }}
         with:
           bundle_image: ${{ env.operator_bundle }}
           namespace: ${{ inputs.namespace }}
@@ -299,7 +313,7 @@ jobs:
           path: /tmp/images
 
       - name: Start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
         with:
           memory: 6500M
 
@@ -313,7 +327,7 @@ jobs:
           ; done
 
       - name: Make bundle
-        uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
+        uses: konveyor/tackle2-operator/.github/actions/make-bundle@${{ inputs.operator_branch }}
         with:
           operator_bundle: ${{ env.operator_bundle }}
           operator: ${{ inputs.operator }}
@@ -329,7 +343,7 @@ jobs:
         run: docker push ${operator_bundle}
 
       - name: Install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@main
+        uses: konveyor/tackle2-operator/.github/actions/install-konveyor@${{ inputs.operator_branch }}
         with:
           bundle_image: ${{ env.operator_bundle }}
           namespace: ${{ inputs.namespace }}

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -11,6 +11,13 @@ on:
         required: false
         type: string
         default: latest
+      operator_branch:
+        description: |
+          The branch name for operator to be used for setup, e.g. a build for release-0.2,
+          you would specify "release-0.2".
+        required: false
+        type: string
+        default: main
       component_name:
         description: |
           The name of the component being tested, ie konveyor-hub, analyzer-lsp, etc.
@@ -72,6 +79,13 @@ on:
         required: false
         type: string
         default: latest
+      operator_branch:
+        description: |
+          The branch name for operator to be used for setup, e.g. a build for release-0.2,
+          you would specify "release-0.2".
+        required: false
+        type: string
+        default: main
       component_name:
         description: |
           The name of the component being tested, ie konveyor-hub, analyzer-lsp, etc.
@@ -161,7 +175,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
         with:
           memory: 6500M
 
@@ -174,7 +188,7 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -243,7 +257,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
 
       # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image
@@ -254,7 +268,7 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -11,13 +11,13 @@ on:
         required: false
         type: string
         default: latest
-      operator_branch:
+      operator_tag:
         description: |
-          The branch name for operator to be used for setup, e.g. a build for release-0.2,
-          you would specify "release-0.2".
+          The tag name for operator to be used for setup, e.g. a build for release-0.3,
+          you would specify "v0.3.0".
         required: false
         type: string
-        default: main
+        default: latest
       component_name:
         description: |
           The name of the component being tested, ie konveyor-hub, analyzer-lsp, etc.
@@ -79,13 +79,13 @@ on:
         required: false
         type: string
         default: latest
-      operator_branch:
+      operator_tag:
         description: |
-          The branch name for operator to be used for setup, e.g. a build for release-0.2,
-          you would specify "release-0.2".
+          The tag name for operator to be used for setup, e.g. a build for release-0.3,
+          you would specify "v0.3.0".
         required: false
         type: string
-        default: main
+        default: latest
       component_name:
         description: |
           The name of the component being tested, ie konveyor-hub, analyzer-lsp, etc.
@@ -189,9 +189,9 @@ jobs:
 
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
-        if: "${{ inputs.operator_branch == 'release-0.4'}}"
+        if: "${{ startsWith(inputs.operator_tag, 'v0.4') }}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
@@ -200,9 +200,9 @@ jobs:
           analyzer-container-cpu: 0
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
-        if: "${{ inputs.operator_branch == 'release-0.3'}}"
+        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
@@ -211,9 +211,9 @@ jobs:
           analyzer-container-cpu: 0
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
-        if: "${{ inputs.operator_branch == 'main'}}"
+        if: "${{ inputs.operator_tag == 'latest'}}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
@@ -291,10 +291,10 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
-        if: "${{ inputs.operator_branch == 'release-0.3'}}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
+        if: "${{ startsWith(inputs.operator_tag, 'v0.4') }}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
@@ -302,10 +302,10 @@ jobs:
           analyzer-container-memory: 0
           analyzer-container-cpu: 0
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
-        if: "${{ inputs.operator_branch == 'release-0.4'}}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
+        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
@@ -314,9 +314,9 @@ jobs:
           analyzer-container-cpu: 0
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
-        if: "${{ inputs.operator_branch == 'main'}}"
+        if: "${{ inputs.operator_tag == 'latest'}}"
         with:
-          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -175,7 +175,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
+        uses: "konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}"
         with:
           memory: 6500M
 
@@ -188,7 +188,7 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}
+        uses: "konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -257,7 +257,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}
+        uses: "konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}"
 
       # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image
@@ -268,7 +268,7 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}
+        uses: "konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -175,7 +175,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: "konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}"
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
         with:
           memory: 6500M
 
@@ -188,7 +188,30 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: "konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
+        if: "${{ inputs.operator_branch == 'release-0.4'}}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
+        if: "${{ inputs.operator_branch == 'release-0.3'}}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
+        if: "${{ inputs.operator_branch == 'main'}}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -257,7 +280,7 @@ jobs:
           path: /tmp
 
       - name: start minikube
-        uses: "konveyor/tackle2-operator/.github/actions/start-minikube@${{ inputs.operator_branch }}"
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
 
       # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image
@@ -268,7 +291,30 @@ jobs:
           docker load --input /tmp/${{ inputs.component_name }}.tar
 
       - name: install konveyor
-        uses: "konveyor/tackle2-operator/.github/actions/install-tackle@${{ inputs.operator_branch }}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
+        if: "${{ inputs.operator_branch == 'release-0.3'}}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
+        if: "${{ inputs.operator_branch == 'release-0.4'}}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
+        if: "${{ inputs.operator_branch == 'main'}}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"

--- a/.github/workflows/nightly-release-0.3.yaml
+++ b/.github/workflows/nightly-release-0.3.yaml
@@ -10,13 +10,13 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       tag: release-0.3
+      operator_tag: v0.3.2
       api_tests_ref: release-0.3
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.3 specific branch
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
-      operator_branch: release-0.3
   report_failure:
     needs: release-0_3-nightly
     if: ${{ always() && contains(needs.*.result, 'failure') }}

--- a/.github/workflows/nightly-release-0.3.yaml
+++ b/.github/workflows/nightly-release-0.3.yaml
@@ -16,6 +16,7 @@ jobs:
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
+      operator_branch: release-0.3
   report_failure:
     needs: release-0_3-nightly
     if: ${{ always() && contains(needs.*.result, 'failure') }}

--- a/.github/workflows/nightly-release-0.3.yaml
+++ b/.github/workflows/nightly-release-0.3.yaml
@@ -12,6 +12,7 @@ jobs:
       tag: release-0.3
       operator_tag: v0.3.2
       api_tests_ref: release-0.3
+      api_hub_tests_ref: release-0.3
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.3 specific branch
       ui_tests_ref: main

--- a/.github/workflows/nightly-release-0.3.yaml
+++ b/.github/workflows/nightly-release-0.3.yaml
@@ -12,7 +12,6 @@ jobs:
       tag: release-0.3
       operator_tag: v0.3.2
       api_tests_ref: release-0.3
-      api_hub_tests_ref: release-0.3
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.3 specific branch
       ui_tests_ref: main

--- a/.github/workflows/nightly-release-0.4.yaml
+++ b/.github/workflows/nightly-release-0.4.yaml
@@ -16,6 +16,7 @@ jobs:
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
+      operator_branch: release-0.4
   report_failure:
     needs: release-0_4-nightly
     if: ${{ always() && contains(needs.*.result, 'failure') }}

--- a/.github/workflows/nightly-release-0.4.yaml
+++ b/.github/workflows/nightly-release-0.4.yaml
@@ -10,13 +10,13 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       tag: release-0.4
+      operator_tag: v0.4.0
       api_tests_ref: release-0.4
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.4 specific branch
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
-      operator_branch: release-0.4
   report_failure:
     needs: release-0_4-nightly
     if: ${{ always() && contains(needs.*.result, 'failure') }}

--- a/.github/workflows/nightly-release-0.4.yaml
+++ b/.github/workflows/nightly-release-0.4.yaml
@@ -12,6 +12,7 @@ jobs:
       tag: release-0.4
       operator_tag: v0.4.0
       api_tests_ref: release-0.4
+      api_hub_tests_ref: release-0.4
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.4 specific branch
       ui_tests_ref: main

--- a/.github/workflows/nightly-release-0.4.yaml
+++ b/.github/workflows/nightly-release-0.4.yaml
@@ -12,7 +12,6 @@ jobs:
       tag: release-0.4
       operator_tag: v0.4.0
       api_tests_ref: release-0.4
-      api_hub_tests_ref: release-0.4
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.4 specific branch
       ui_tests_ref: main


### PR DESCRIPTION
Update of global-ci action to allow set operator branch name used for install/setup scripts.