### PR TITLE
Use release branches for start-minikube

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -175,7 +175,20 @@ jobs:
           path: /tmp
 
       - name: start minikube
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.4
+        if: "${{ startsWith(inputs.operator_tag, 'v0.4') }}"
+        with:
+          memory: 'max'
+          cpus: 'max'
+      - name: start minikube
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.3
+        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
+        with:
+          memory: 'max'
+          cpus: 'max'
+      - name: start minikube
         uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        if: "${{ startsWith(inputs.operator_tag, 'latest') }}"
         with:
           memory: 'max'
           cpus: 'max'


### PR DESCRIPTION
This should fix CI on setup step for workflows using global-ci.yml.