### PR TITLE
Don't build images on nightly main

### DIFF
--- a/.github/workflows/nightly-main.yaml
+++ b/.github/workflows/nightly-main.yaml
@@ -9,6 +9,7 @@ jobs:
   main-nightly:
     uses: ./.github/workflows/global-ci-bundle.yml
     with:
+      operator_bundle: quay.io/konveyor/tackle2-operator-bundle:latest
       api_tests_ref: main
       run_api_tests: true
       ui_tests_ref: main


### PR DESCRIPTION
Updating nightly CI job for main branch to not build the operator bundle and publish it to ttl.io on its own, but use latest existing from quay.io.

@djzager Please correct me if this is something really wrong, thanks!