### PR TITLE
Add release-0.6 job and badge

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -199,8 +199,8 @@ jobs:
           memory: 'max'
           cpus: 'max'
       - name: start minikube
-        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.3
-        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.6
+        if: "${{ startsWith(inputs.operator_tag, 'v0.6') }}"
         with:
           memory: 'max'
           cpus: 'max'

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -231,8 +231,8 @@ jobs:
           analyzer-container-memory: 0
           analyzer-container-cpu: 0
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
-        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.5
+        if: "${{ startsWith(inputs.operator_tag, 'v0.5') }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -242,8 +242,8 @@ jobs:
           analyzer-container-memory: 0
           analyzer-container-cpu: 0
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.5
-        if: "${{ startsWith(inputs.operator_tag, 'v0.5') }}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.6
+        if: "${{ startsWith(inputs.operator_tag, 'v0.6') }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -348,8 +348,19 @@ jobs:
           analyzer-container-memory: 0
           analyzer-container-cpu: 0
       - name: install konveyor
-        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.3
-        if: "${{ startsWith(inputs.operator_tag, 'v0.3') }}"
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.5
+        if: "${{ startsWith(inputs.operator_tag, 'v0.5') }}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.6
+        if: "${{ startsWith(inputs.operator_tag, 'v0.6') }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"

--- a/.github/workflows/nightly-release-0.6.yaml
+++ b/.github/workflows/nightly-release-0.6.yaml
@@ -1,24 +1,24 @@
-name: Run Konveyor release-0.3 nightly tests
+name: Run Konveyor release-0.6 nightly tests
 
 on:
   schedule:
-    - cron: "13 4 * * *"
+    - cron: "16 4 * * *"
   workflow_dispatch:
 
 jobs:
-  release-0_3-nightly:
+  release-0_6-nightly:
     uses: ./.github/workflows/global-ci.yml
     with:
-      tag: release-0.3
-      operator_tag: v0.3.2
-      api_tests_ref: release-0.3
+      tag: release-0.6
+      operator_tag: v0.6.0-beta.1
+      api_tests_ref: release-0.6
       run_api_tests: true
-      # TODO: this needs to be pinned to a release-0.3 specific branch
+      # TODO: this needs to be pinned to a release-0.6 specific branch
       ui_tests_ref: main
       # Disabled while we wait for stability
       run_ui_tests: false
   report_failure:
-    needs: release-0_3-nightly
+    needs: release-0_6-nightly
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
           payload: |
             {
               "test": "E2E API",
-              "branch": "release-0.3",
+              "branch": "release-0.6",
               "note": "Failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Component | CI (after merge) | Nightly (cron)
 Branch | Status
 --|--
 **main** | [![Run Konveyor main nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-main.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-main.yaml)
+**release-0.6** | [![Run Konveyor release-0.6 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.6.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.6.yaml)
 **release-0.5** | [![Run Konveyor release-0.5 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.5.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.5.yaml)
 **release-0.4** | [![Run Konveyor release-0.4 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.4.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.4.yaml)
-**release-0.3** | [![Run Konveyor release-0.3 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.3.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.3.yaml)
 
 
 


### PR DESCRIPTION
Removing release-0.3 and adding release-0.6 to nightly CI.

Fixes: https://github.com/konveyor/ci/issues/69