### PR TITLE
Update action upload-artifact to v4

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -440,7 +440,7 @@ jobs:
           spec: "**/*.test.ts"
 
       - name: Upload cypress report  data as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tackle-ui-test-reports-${{ matrix.tier }}

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -422,7 +422,7 @@ jobs:
           spec: "**/*.test.ts"
 
       - name: Upload cypress report  data as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tackle-ui-test-reports-${{ matrix.tier }}

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ jobs:
           podman save -o /tmp/analyzer-lsp.tar quay.io/konveyor/analyzer-lsp:latest
 
       - name: Upload image as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: analyzer-lsp
+          name: analyzer-lsp    # If uploading multiple artifacts in the workflow, make sure there is a unique name for each
           path: /tmp/analyzer-lsp.tar
           # This prevents too many artifacts from accumulating in your repository
           retention-days: 1


### PR DESCRIPTION
Updating upload-artifact from v3 to v4, only difference should be, that since v4, each artifact needs its own anme (v3 added multiple artifacts with the same names), this limit should not be problem for us.