### PR TITLE
Use v0.6.0 bundle for release-0.6

### DIFF
--- a/.github/workflows/nightly-release-0.6.yaml
+++ b/.github/workflows/nightly-release-0.6.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       tag: release-0.6
-      operator_tag: v0.6.0-rc.2
+      operator_tag: v0.6.0
       api_tests_ref: release-0.6
       run_api_tests: true
       # TODO: this needs to be pinned to a release-0.6 specific branch


### PR DESCRIPTION
Updating release-0.6 nightly test to use released 0.6 tag.