### PR TITLE
Update e2e ui tests, harmonize the inputs and test running

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -91,6 +91,12 @@ on:
         required: false
         type: string
         default: main
+      api_tests_tiers:
+        description: |
+          The make command to execute from go-konveyor-tests repository
+        required: false
+        type: string
+        default: make test-tier0 test-tier1
       api_hub_tests_ref:
           description: |
             The branch or PR of the Hub API tests from tackle2-hub repository to clone.
@@ -111,6 +117,15 @@ on:
         required: false
         type: string
         default: main
+      ui_test_tags:
+        description: |
+          A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
+          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
+          the value should be: "@tier0,@tier1,@tier2".
+        required: false
+        type: string
+        default: "@tier0"
+
   workflow_dispatch:
     inputs:
       operator_bundle:
@@ -155,6 +170,12 @@ on:
         required: false
         type: string
         default: main
+      api_tests_tiers:
+        description: |
+          The make command to execute from go-konveyor-tests repository
+        required: false
+        type: string
+        default: make test-tier0 test-tier1
       ui_tests_ref:
         description: |
           The branch or PR of the tackle-ui-tests repository to clone.
@@ -167,6 +188,14 @@ on:
         required: false
         type: string
         default: main
+      ui_test_tags:
+        description: |
+          A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
+          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
+          the value should be: "@tier0,@tier1,@tier2".
+        required: false
+        type: string
+        default: "@tier0"
 
 env:
   operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h
@@ -310,19 +339,20 @@ jobs:
         run: |
           export HUB_BASE_URL="http://$(minikube ip)/hub"
           export HUB_TESTS_REF="${{ inputs.api_hub_tests_ref }}"
-          make test-tier0 test-tier1
+          ${{ inputs.api_tests_tiers }}
         working-directory: go-konveyor-tests
 
   e2e-ui-integration-tests:
     needs: check-images
     if: ${{ inputs.run_ui_tests }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # TODO: Support cypress-split in main tackle-ui-test project
-        # split: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-        tier: [tier1, tier2, tier3]
+
+    # Note: We can split the input string by comma if we want to run the tags in parallel
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     test-tags:
+    #       - ${{ inputs.ui_test_tags }}
 
     steps:
       - name: Extract pull request number from inputs or PR description
@@ -413,7 +443,7 @@ jobs:
           echo "UI_URL=https://$(minikube ip)" >>$GITHUB_ENV
 
       - name: Run login tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         env:
           CYPRESS_user: admin
           CYPRESS_pass: password
@@ -423,27 +453,27 @@ jobs:
           spec: "cypress/e2e/tests/login.test.ts"
 
       - name: Run UI tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         env:
-          CYPRESS_INCLUDE_TAGS: "@${{ matrix.tier }}"
+          CYPRESS_INCLUDE_TAGS: "@${{ input.ui_test_tags }}"
           CYPRESS_user: "admin"
           CYPRESS_pass: "Dog8code"
           CYPRESS_tackleUrl: "${{ env.UI_URL }}"
           CYPRESS_git_user: "fakeuser"
           CYPRESS_git_password: "${{ secrets.GITHUB_TOKEN }}"
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"
-          # TODO: Support cypress-split in main tackle-ui-test project
-          # CYPRESS_split: "${{ strategy.job-total }}"
-          # CYPRESS_splitIndex: "${{ strategy.job-index }}"
         with:
           working-directory: tackle-ui-tests
+          # spec can be removed once https://github.com/konveyor/tackle-ui-tests/pull/1331 merges
           spec: "**/*.test.ts"
 
-      - name: Upload cypress report  data as artifact
+      - name: Upload cypress report data as artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tackle-ui-test-reports-${{ matrix.tier }}
+          name: tackle-ui-test-reports-${{ input.ui_test_tags }}
           path: |
             tackle-ui-tests/cypress/reports
             tackle-ui-tests/cypress/screenshots
+            tackle-ui-tests/cypress/videos
+

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -75,6 +75,14 @@ on:
         required: false
         type: string
         default: main
+      ui_test_tags:
+        description: |
+          A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
+          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
+          the value should be: "@tier0,@tier1,@tier2".
+        required: false
+        type: string
+        default: "@tier0"
   workflow_dispatch:
     inputs:
       tag:
@@ -149,6 +157,14 @@ on:
         required: false
         type: string
         default: main
+      ui_test_tags:
+        description: |
+          A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
+          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
+          the value should be: "@tier0,@tier1,@tier2".
+        required: false
+        type: string
+        default: "@tier0"
 
 jobs:
   e2e-api-integration-tests:
@@ -211,13 +227,14 @@ jobs:
           memory: 'max'
           cpus: 'max'
 
-      # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image
         if: "${{ inputs.component_name != '' }}"
         run: |
           export SHELL=/bin/bash
           eval $(minikube -p minikube docker-env)
-          docker load --input /tmp/${{ inputs.component_name }}.tar
+          for image in $(ls /tmp/images/*.tar); do
+            docker load --input ${image}
+          ; done
 
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
@@ -284,11 +301,13 @@ jobs:
   e2e-ui-integration-tests:
     if: ${{ inputs.run_ui_tests }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # TODO enable customizing the number of tiers run for nightlies
-        tier: [tier0] #, tier1, tier2, tier3]
+
+    # Note: We can split the input string by comma if we want to run the tags in parallel
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     test-tags:
+    #       - ${{ inputs.ui_test_tags }}
 
     steps:
       - name: Extract pull request number from inputs or PR description
@@ -328,13 +347,14 @@ jobs:
           memory: 'max'
           cpus: 'max'
 
-      # TODO: Could just load all images found in this artifact so that people can rebuild multiple components if needed
       - name: Load image
         if: "${{ inputs.component_name != '' }}"
         run: |
           export SHELL=/bin/bash
           eval $(minikube -p minikube docker-env)
-          docker load --input /tmp/${{ inputs.component_name }}.tar
+          for image in $(ls /tmp/images/*.tar); do
+            docker load --input ${image}
+          ; done
 
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4
@@ -397,20 +417,20 @@ jobs:
           echo $external_ip;
           echo "UI_URL=https://$(minikube ip)" >>$GITHUB_ENV
 
-      # - name: Run login tests
-      #   uses: cypress-io/github-action@v5
-      #   env:
-      #     CYPRESS_user: admin
-      #     CYPRESS_pass: password
-      #     CYPRESS_tackleUrl: "${{ env.UI_URL }}"
-      #   with:
-      #     working-directory: tackle-ui-tests
-      #     spec: "cypress/e2e/tests/login.test.ts"
-
-      - name: Run UI tests
-        uses: cypress-io/github-action@v5
+      - name: Run login tests
+        uses: cypress-io/github-action@v6
         env:
-          CYPRESS_INCLUDE_TAGS: "@${{ matrix.tier }}"
+          CYPRESS_user: admin
+          CYPRESS_pass: password
+          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
+        with:
+          working-directory: tackle-ui-tests
+          spec: "cypress/e2e/tests/login.test.ts"
+
+      - name: Run UI tests (${{ inputs.ui_test_tags }})
+        uses: cypress-io/github-action@v6
+        env:
+          CYPRESS_INCLUDE_TAGS: "${{ inputs.ui_test_tags }}"
           CYPRESS_user: "admin"
           CYPRESS_pass: "Dog8code"
           CYPRESS_tackleUrl: "${{ env.UI_URL }}"
@@ -419,13 +439,15 @@ jobs:
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"
         with:
           working-directory: tackle-ui-tests
+          # spec can be removed once https://github.com/konveyor/tackle-ui-tests/pull/1331 merges
           spec: "**/*.test.ts"
 
-      - name: Upload cypress report  data as artifact
+      - name: Upload cypress report data as artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tackle-ui-test-reports-${{ matrix.tier }}
+          name: tackle-ui-test-reports-${{ inputs.test-tags }}
           path: |
             tackle-ui-tests/cypress/reports
             tackle-ui-tests/cypress/screenshots
+            tackle-ui-tests/cypress/videos


### PR DESCRIPTION
Bring the two global ci workflows in harmony with each other by:

  - Both workflows can specify inputs:
    - `api_tests_tiers` to define the API tests to run
    - `ui_test_tags` to define the UI tests to run

  - Both workflows will `docker load` all of the tar files present in their defined (`artifact` or `component_name` input props) downloaded artifacts

  - e2e UI tests do not need to run in parallel

  - Default e2e UI tests to run `@tier0` tests

  - Bump to action UI tests to use `cypress-io/github-action@v6`