### PR TITLE
Fix loop syntax in global-ci

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -296,7 +296,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           for image in $(ls /tmp/images/*.tar); do
             docker load --input ${image}
-          ; done
+          done
 
       - name: Make bundle
         if: ${{ inputs.operator_bundle == '' }}
@@ -399,7 +399,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           for image in $(ls /tmp/images/*.tar); do
             docker load --input ${image}
-          ; done
+          done
 
       - name: Make bundle
         if: ${{ inputs.operator_bundle == '' }}

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -234,7 +234,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           for image in $(ls /tmp/images/*.tar); do
             docker load --input ${image}
-          ; done
+          done
 
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -354,7 +354,7 @@ jobs:
           eval $(minikube -p minikube docker-env)
           for image in $(ls /tmp/images/*.tar); do
             docker load --input ${image}
-          ; done
+          done
 
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.4


### PR DESCRIPTION
CI raised bash syntax error when component name was present, removing ; before done.

Related to https://github.com/konveyor/ci/pull/77