### PR TITLE
Update global ci default UI testing tag to `@ci`

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -120,11 +120,11 @@ on:
       ui_test_tags:
         description: |
           A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
-          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
-          the value should be: "@tier0,@tier1,@tier2".
+          needs to be explicitly included in the list. For example, to use tiers ci, 0, 1, and 2,
+          the value should be: "@ci,@tier0,@tier1,@tier2".
         required: false
         type: string
-        default: "@tier0"
+        default: "@ci"
 
   workflow_dispatch:
     inputs:
@@ -191,11 +191,11 @@ on:
       ui_test_tags:
         description: |
           A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
-          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
-          the value should be: "@tier0,@tier1,@tier2".
+          needs to be explicitly included in the list. For example, to use tiers ci, 0, 1, and 2,
+          the value should be: "@ci,@tier0,@tier1,@tier2".
         required: false
         type: string
-        default: "@tier0"
+        default: "@ci"
 
 env:
   operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -78,11 +78,11 @@ on:
       ui_test_tags:
         description: |
           A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
-          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
-          the value should be: "@tier0,@tier1,@tier2".
+          needs to be explicitly included in the list. For example, to use tiers ci, 0, 1, and 2,
+          the value should be: "@ci,@tier0,@tier1,@tier2".
         required: false
         type: string
-        default: "@tier0"
+        default: "@ci"
   workflow_dispatch:
     inputs:
       tag:
@@ -160,11 +160,11 @@ on:
       ui_test_tags:
         description: |
           A comma separated list of test tags/tiers to select the ui tests to run. Each tag/tier
-          needs to be explicitly included in the list. For example, to use tiers 0, 1, and 2,
-          the value should be: "@tier0,@tier1,@tier2".
+          needs to be explicitly included in the list. For example, to use tiers ci, 0, 1, and 2,
+          the value should be: "@ci,@tier0,@tier1,@tier2".
         required: false
         type: string
-        default: "@tier0"
+        default: "@ci"
 
 jobs:
   e2e-api-integration-tests:


### PR DESCRIPTION
A recent change in the UI tests repo [1] changed the basic CI testing suite from `@tier0` to `@ci`. Updating the CI workflows to use the new tier.

[1]: https://github.com/konveyor/tackle-ui-tests/pull/1351