### PR TITLE
Update e2e UI test env vars

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -464,7 +464,7 @@ jobs:
         env:
           CYPRESS_user: admin
           CYPRESS_pass: password
-          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
+          CYPRESS_baseUrl: "${{ env.UI_URL }}"
         with:
           working-directory: tackle-ui-tests
           spec: "cypress/e2e/tests/login.test.ts"
@@ -475,7 +475,7 @@ jobs:
           CYPRESS_INCLUDE_TAGS: "${{ inputs.ui_test_tags }}"
           CYPRESS_user: "admin"
           CYPRESS_pass: "Dog8code"
-          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
+          CYPRESS_baseUrl: "${{ env.UI_URL }}"
           CYPRESS_git_user: "fakeuser"
           CYPRESS_git_password: "${{ secrets.GITHUB_TOKEN }}"
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -439,7 +439,7 @@ jobs:
         env:
           CYPRESS_user: admin
           CYPRESS_pass: password
-          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
+          CYPRESS_baseUrl: "${{ env.UI_URL }}"
         with:
           working-directory: tackle-ui-tests
           spec: "cypress/e2e/tests/login.test.ts"
@@ -450,7 +450,7 @@ jobs:
           CYPRESS_INCLUDE_TAGS: "${{ inputs.ui_test_tags }}"
           CYPRESS_user: "admin"
           CYPRESS_pass: "Dog8code"
-          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
+          CYPRESS_baseUrl: "${{ env.UI_URL }}"
           CYPRESS_git_user: "fakeuser"
           CYPRESS_git_password: "${{ secrets.GITHUB_TOKEN }}"
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
To pair with changes in konveyor/tackle-ui-tests#1411, update the url env var to `CYPRESS_baseUrl`.