### PR TITLE
Update UI login test initial/password configs and ingress wait

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -474,7 +474,8 @@ jobs:
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_user: admin
-          CYPRESS_pass: password
+          CYPRESS_initialPassword: Passw0rd!
+          CYPRESS_password: Dog8code
           CYPRESS_baseUrl: "${{ env.UI_URL }}"
         with:
           working-directory: tackle-ui-tests

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -457,18 +457,10 @@ jobs:
 
       - name: Wait for Ingress and expose UI service
         run: |
-          external_ip=""
-          echo $external_ip;
-          while [[ -z $external_ip ]]
-            do
-              echo "Waiting for end point..."
-                external_ip=$(kubectl get ingress tackle --template="{{range.status.loadBalancer.ingress}}{{.ip}}{{end}}" -n konveyor-tackle);[[ -z $external_ip ]] &&
-                echo $external_ip;
-                sleep 10;
-            done
-          echo "End point ready:" &&
-          echo $external_ip;
-          echo "UI_URL=https://$(minikube ip)" >>$GITHUB_ENV
+          kubectl wait -n konveyor-tackle ingress/tackle --for=jsonpath='{.status.loadBalancer.ingress[0]}' --timeout=600s
+          minikube_ip=$(minikube ip)
+          echo "ingress is ready at: ${minikube_ip}"
+          echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
 
       - name: Run login tests
         uses: cypress-io/github-action@v6

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -421,7 +421,8 @@ jobs:
         uses: cypress-io/github-action@v6
         env:
           CYPRESS_user: admin
-          CYPRESS_pass: password
+          CYPRESS_initialPassword: Passw0rd!
+          CYPRESS_password: Dog8code
           CYPRESS_baseUrl: "${{ env.UI_URL }}"
           CYPRESS_tackleUrl: "${{ env.UI_URL }}"
         with:

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -404,18 +404,10 @@ jobs:
 
       - name: Wait for Ingress and expose UI service
         run: |
-          external_ip=""
-          echo $external_ip;
-          while [[ -z $external_ip ]]
-            do
-              echo "Waiting for end point..."
-                external_ip=$(kubectl get ingress tackle --template="{{range.status.loadBalancer.ingress}}{{.ip}}{{end}}" -n konveyor-tackle);[[ -z $external_ip ]] &&
-                echo $external_ip;
-                sleep 10;
-            done
-          echo "End point ready:" &&
-          echo $external_ip;
-          echo "UI_URL=https://$(minikube ip)" >>$GITHUB_ENV
+          kubectl wait -n konveyor-tackle ingress/tackle --for=jsonpath='{.status.loadBalancer.ingress[0]}' --timeout=600s
+          minikube_ip=$(minikube ip)
+          echo "ingress is ready at: ${minikube_ip}"
+          echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
 
       - name: Run login tests
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
With https://github.com/konveyor/tackle-ui-tests/pull/1543, it is possible to provide the default admin user password that needs to be changed on first login.  While the test configs embed the default username and password, it is useful to explicitly define them in the workflow so we know exactly what is being used.

Use the same ingress wait as https://github.com/konveyor/tackle-ui-tests/blob/6a7e88b54e63d15e122441a2bef1fe123a7a6a7f/.github/workflows/run-ui-tests.yaml#L85-L95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated environment variables used in UI integration tests for login credentials.
  * Improved the reliability and efficiency of UI service readiness checks during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->