### PR TITLE
Add base_tag for bundle on top of release branch

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -208,7 +208,7 @@ on:
         default: "@ci"
 
 env:
-  operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:2h
+  operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:4h
 
 jobs:
   check-images:

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -14,6 +14,11 @@ on:
         type: string
         required: false
         default: ""
+      base_tag:
+        description: tag for operator image (ie. release-0.7) to build custom bundle on top of it. Is added to operator base image URL.
+        type: string
+        required: false
+        default: "latest"
       oauth_proxy:
         description: image uri for oauth_proxy (ie. quay.io/<namespace>/<image-name>:<tag>)
         type: string
@@ -133,6 +138,11 @@ on:
         type: string
         required: false
         default: "quay.io/konveyor/tackle2-operator-bundle:latest"
+      base_tag:
+        description: tag for operator image (ie. release-0.7) to build custom bundle on top of it. Is added to operator base image URL.
+        type: string
+        required: false
+        default: "latest"
       namespace:
         description: |
           Namespace for the konveyor install.
@@ -312,6 +322,7 @@ jobs:
         uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
         with:
           operator_bundle: ${{ env.operator_bundle }}
+          operator: quay.io/konveyor/tackle2-operator:${{ inputs.base_tag }}
           oauth_proxy: ${{ inputs.oauth_proxy }}
           tackle_hub: ${{ inputs.tackle_hub }}
           tackle_postgres: ${{ inputs.tackle_postgres }}
@@ -434,6 +445,7 @@ jobs:
         uses: konveyor/tackle2-operator/.github/actions/make-bundle@main
         with:
           operator_bundle: ${{ env.operator_bundle }}
+          operator: quay.io/konveyor/tackle2-operator:${{ inputs.base_tag }}
           oauth_proxy: ${{ inputs.oauth_proxy }}
           tackle_hub: ${{ inputs.tackle_hub }}
           tackle_postgres: ${{ inputs.tackle_postgres }}


### PR DESCRIPTION
The global-ci-bundle allows to specify bundle name, however when building a custom Konveyor build (e.g. on Hub PR), it always used `:latest` as a base for operator (and so related components).

This did not work for release branches with recent bigger changes in Konveyor main, so adding base_tag input to global-ci-bundle workflow that allow specify release branch that should be used for custom bundle build.

The operator `make-bundle` action already accept the operator tag, that used its default from operator Makefile [0]. This change allows set this field from CI.

Should fix CI failure on https://github.com/konveyor/tackle2-hub/pull/846 and other cherry-picks for release branches.

[0] https://github.com/konveyor/operator/blob/main/Makefile#L69 and https://github.com/konveyor/operator/blob/main/.github/actions/make-bundle/action.yml#L77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new optional input to the CI workflow, allowing users to specify the operator image tag when building custom operator bundles. The default tag is set to "latest".
  * Increased the time-to-live for operator bundle environment variables from 2 to 4 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->