### PR TITLE
For release-0.6 branch tackleUrl is still used

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -423,6 +423,7 @@ jobs:
           CYPRESS_user: admin
           CYPRESS_pass: password
           CYPRESS_baseUrl: "${{ env.UI_URL }}"
+          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
         with:
           working-directory: tackle-ui-tests
           spec: "cypress/e2e/tests/login.test.ts"
@@ -434,6 +435,7 @@ jobs:
           CYPRESS_user: "admin"
           CYPRESS_pass: "Dog8code"
           CYPRESS_baseUrl: "${{ env.UI_URL }}"
+          CYPRESS_tackleUrl: "${{ env.UI_URL }}"
           CYPRESS_git_user: "fakeuser"
           CYPRESS_git_password: "${{ secrets.GITHUB_TOKEN }}"
           CYPRESS_git_key: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end UI test workflow to set an additional environment variable for test steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->