### PR TITLE
Update go-version in global-ci-bundle.yml workflow

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -335,7 +335,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Install test dependencies
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow to use Go version 1.21 for API integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->