### PR TITLE
Update summary step handle setup failures

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -353,7 +353,7 @@ jobs:
         working-directory: go-konveyor-tests
       - name: Prepare summary
         if: always()
-        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: [[ -f /tmp/tests.log ]] && cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY; true
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -353,7 +353,10 @@ jobs:
         working-directory: go-konveyor-tests
       - name: Prepare summary
         if: always()
-        run: [[ -f /tmp/tests.log ]] && cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY; true
+        run: |
+          if [[ -f /tmp/tests.log ]]; then
+            grep -- '---' /tmp/tests.log >> "$GITHUB_STEP_SUMMARY"
+          fi || true
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -292,7 +292,7 @@ jobs:
         working-directory: go-konveyor-tests
       - name: Prepare summary
         if: always()
-        run: cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY
+        run: [[ -f /tmp/tests.log ]] && cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY; true
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -292,7 +292,10 @@ jobs:
         working-directory: go-konveyor-tests
       - name: Prepare summary
         if: always()
-        run: [[ -f /tmp/tests.log ]] && cat /tmp/tests.log | grep -- --- >> $GITHUB_STEP_SUMMARY; true
+        run: |
+          if [[ -f /tmp/tests.log ]]; then
+            grep -- '---' /tmp/tests.log >> "$GITHUB_STEP_SUMMARY"
+          fi || true
       - name: Upload analysis tests output
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Updating summary step to not fail when the workflow failed too soon to create a tests execution log file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability by ensuring summary preparation steps do not fail if test log files are missing during automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->