### PR TITLE
Update go-version in global-ci.yml workflow

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -276,7 +276,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Install test dependencies
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version used in continuous integration workflows from 1.18 to 1.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->