### PR TITLE
Add CI shared test cases

### DIFF
--- a/shared_tests/README.md
+++ b/shared_tests/README.md
@@ -1,0 +1,45 @@
+# Konveyor CI shared test cases
+
+Konveyor project affers multiple way of application analysis. There is a shared set of end-to-end basic application analyses that is tested with all relevant components (as an addition to their tests) and this is considered as a source of truth for analysis results.
+
+Component test suites that should use those shared tests are:
+- API - E2E tests https://github.com/konveyor/go-konveyor-tests/
+- CLI - kantra tests (container&containerless including Windows) https://github.com/konveyor-ecosystem/kantra-cli-tests/
+- (optional) UI - E2E tests with cypress https://github.com/konveyor/tackle-ui-tests/
+
+## Format of shared test cases
+
+```
+└── shared_tests
+    └── analysis_book-server    # `analysis_` + name of the test, usually name of the application
+        ├── dependencies.yaml   # analyzer-like dependencies output (produced in full analysis mode)
+        ├── output.yaml         # analyzer-like analysis output (contain ruleset with violations/issues reported and optionally Tags on technology usage and discovery)
+        ├── tc.yaml             # analysis test definition (application link, sources, targets, etc.)
+        └── <input_app>         # Test application binary (or ommited if linked from remote git repo)
+```
+
+```
+# tc.yaml
+---
+description: <description of the test, could be just name of the app or more detailed>
+input: <input application to be analyzed, absolute link to e.g. github or local path for binary relative to this file>
+sources: <array of sources, use [] if empty>
+targets: <array of targets, use [] if empty>
+options: <optional array of name,value pairs, e.g. for maven settings file and other advanced options>
+# Example:
+#- name: maven-settings
+#  value: ./settings.yaml
+
+```
+
+Check out [book-server test case](analysis_book-server/) as an example.
+
+## Notes
+
+Assertion of output.yaml:
+- List of rulesets might be filtered for items that contain `violations` field to get only reported issues (without tags).
+- Tags _could_ be tested with filtering `output.yaml` for rulesets names `discovery-rules` and `technology-usage`.
+- Incident file paths (`uri` in incident) should be asserted with _end_with_ since its path prefix might been removed already to keep compatibility for container-based and container-less analyses.
+
+More information about shared tests in CI generaly: https://github.com/konveyor/enhancements/pull/228
+

--- a/shared_tests/analysis_book-server/dependencies.yaml
+++ b/shared_tests/analysis_book-server/dependencies.yaml
@@ -1,0 +1,364 @@
+- dependencies:
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: ch.qos.logback.logback-classic
+    prefix: m2/repository/ch/qos/logback/logback-classic/1.2.3
+    resolvedIdentifier: bc627b0345626c9dfa55eac703602c3a7846950b
+    type: compile
+    version: 1.2.3
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: ch.qos.logback.logback-core
+    prefix: m2/repository/ch/qos/logback/logback-core/1.2.3
+    resolvedIdentifier: a8d536fbd395b033310f686c4085eec5d6099b0f
+    type: compile
+    version: 1.2.3
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.classmate
+    prefix: m2/repository/com/fasterxml/classmate/1.3.4
+    resolvedIdentifier: 7cdb40daa6e022a38056c9eeda602b79661cf570
+    type: compile
+    version: 1.3.4
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.core.jackson-annotations
+    prefix: m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.9.0
+    resolvedIdentifier: 1ef050f2a8b27be34031b10c2e3e068767851e8d
+    type: compile
+    version: 2.9.0
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.core.jackson-core
+    prefix: m2/repository/com/fasterxml/jackson/core/jackson-core/2.9.5
+    resolvedIdentifier: 7a946a40bb8e76f2059805a630dc66d9a933003e
+    type: compile
+    version: 2.9.5
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.core.jackson-databind
+    prefix: m2/repository/com/fasterxml/jackson/core/jackson-databind/2.9.5
+    resolvedIdentifier: 7c86d2e22f9c43f93d87b45179b21a1abfdf728d
+    type: compile
+    version: 2.9.5
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.dataformat.jackson-dataformat-xml
+    prefix: m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.9.5
+    resolvedIdentifier: 145e4ba067f21e75d00cff59b717f6fed50709e4
+    type: compile
+    version: 2.9.5
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.datatype.jackson-datatype-jdk8
+    prefix: m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jdk8/2.9.7
+    resolvedIdentifier: 83da1a1e9e59168d4f37a935157e177d30715bde
+    type: compile
+    version: 2.9.7
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.datatype.jackson-datatype-jsr310
+    prefix: m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.9.5
+    resolvedIdentifier: 0aa4e5e52091b11e213f4a8ad3e731ccb8b845c6
+    type: compile
+    version: 2.9.5
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.module.jackson-module-jaxb-annotations
+    prefix: m2/repository/com/fasterxml/jackson/module/jackson-module-jaxb-annotations/2.9.5
+    resolvedIdentifier: 5c7df908ff461d91edd46cf50309b2f4d1c53e94
+    type: compile
+    version: 2.9.5
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.jackson.module.jackson-module-parameter-names
+    prefix: m2/repository/com/fasterxml/jackson/module/jackson-module-parameter-names/2.9.7
+    resolvedIdentifier: bee5bd1b6899234a2bc946e01e22a4d06a70a737
+    type: compile
+    version: 2.9.7
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: com.fasterxml.woodstox.woodstox-core
+    prefix: m2/repository/com/fasterxml/woodstox/woodstox-core/5.0.3
+    resolvedIdentifier: 759ba68f56e64d62acb4577a514de244e47627db
+    type: compile
+    version: 5.0.3
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: javax.annotation.javax.annotation-api
+    prefix: m2/repository/javax/annotation/javax.annotation-api/1.3.2
+    resolvedIdentifier: 302fe96ef206b17f82893083b51b479541fa25ab
+    type: compile
+    version: 1.3.2
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: javax.validation.validation-api
+    prefix: m2/repository/javax/validation/validation-api/2.0.1.Final
+    resolvedIdentifier: c22c6a1c9dc55d3f3dd56e50d9e4e0d7b9e4e6c0
+    type: compile
+    version: 2.0.1.Final
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.apache.logging.log4j.log4j-api
+    prefix: m2/repository/org/apache/logging/log4j/log4j-api/2.11.1
+    resolvedIdentifier: 00e8347519ff232efbd071005784147454922847
+    type: compile
+    version: 2.11.1
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.apache.logging.log4j.log4j-to-slf4j
+    prefix: m2/repository/org/apache/logging/log4j/log4j-to-slf4j/2.11.1
+    resolvedIdentifier: 43a3bca00a4f2680e403d09e4ab767371a76d6a5
+    type: compile
+    version: 2.11.1
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.apache.tomcat.embed.tomcat-embed-core
+    prefix: m2/repository/org/apache/tomcat/embed/tomcat-embed-core/9.0.12
+    resolvedIdentifier: f78653aca072c14260a2f71b882b1ffa14c3efed
+    type: compile
+    version: 9.0.12
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.apache.tomcat.embed.tomcat-embed-el
+    prefix: m2/repository/org/apache/tomcat/embed/tomcat-embed-el/9.0.12
+    resolvedIdentifier: 9750a17bd287a2cfd2b462b53c9dc8a77a28167f
+    type: compile
+    version: 9.0.12
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.apache.tomcat.embed.tomcat-embed-websocket
+    prefix: m2/repository/org/apache/tomcat/embed/tomcat-embed-websocket/9.0.12
+    resolvedIdentifier: 965a5535d91dd47b6e94ca29d1bf961aacc4f07c
+    type: compile
+    version: 9.0.12
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.codehaus.woodstox.stax2-api
+    prefix: m2/repository/org/codehaus/woodstox/stax2-api/3.1.4
+    resolvedIdentifier: 99256d9abcf494e10152ed6212c05927e3033b01
+    type: compile
+    version: 3.1.4
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.hibernate.validator.hibernate-validator
+    prefix: m2/repository/org/hibernate/validator/hibernate-validator/6.0.13.Final
+    resolvedIdentifier: 8e2f0c55e480a68309eb6cebbaa548a3fdf60ba7
+    type: compile
+    version: 6.0.13.Final
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.jboss.logging.jboss-logging
+    prefix: m2/repository/org/jboss/logging/jboss-logging/3.3.2.Final
+    resolvedIdentifier: 9a1f200153da9354766ff5e333635bf6da3ce733
+    type: compile
+    version: 3.3.2.Final
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.projectlombok.lombok
+    prefix: m2/repository/org/projectlombok/lombok/1.18.2
+    resolvedIdentifier: 9d9ff576d39d43f67eb25e467c22646ab9350f62
+    type: compile
+    version: 1.18.2
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.slf4j.jul-to-slf4j
+    prefix: m2/repository/org/slf4j/jul-to-slf4j/1.7.25
+    resolvedIdentifier: 16087adff3efe354a294183376599d95a2cb0e13
+    type: compile
+    version: 1.7.25
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.slf4j.slf4j-api
+    prefix: m2/repository/org/slf4j/slf4j-api/1.7.25
+    resolvedIdentifier: df51c4a85dd6acf8b6cdc9323596766b3d577c28
+    type: compile
+    version: 1.7.25
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot
+    prefix: m2/repository/org/springframework/boot/spring-boot/2.1.0.RELEASE
+    resolvedIdentifier: 453b7a01046343e6f2ea69c421e824650702ac91
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-autoconfigure
+    prefix: m2/repository/org/springframework/boot/spring-boot-autoconfigure/2.1.0.RELEASE
+    resolvedIdentifier: ba2fbf5f4390260af149caa787dc5089a8e789c2
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-starter
+    prefix: m2/repository/org/springframework/boot/spring-boot-starter/2.1.0.RELEASE
+    resolvedIdentifier: f0872b1ee8f7e4413198e6cc7d3812bbd2dec939
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-starter-json
+    prefix: m2/repository/org/springframework/boot/spring-boot-starter-json/2.1.0.RELEASE
+    resolvedIdentifier: 64f504d62cf9932c80c2de1a65c1f3624a3cd535
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-starter-logging
+    prefix: m2/repository/org/springframework/boot/spring-boot-starter-logging/2.1.0.RELEASE
+    resolvedIdentifier: cbaa34e4c34b9b7fdbbcd321596d519145dad8a0
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-starter-tomcat
+    prefix: m2/repository/org/springframework/boot/spring-boot-starter-tomcat/2.1.0.RELEASE
+    resolvedIdentifier: 5311dfe17201875f4d8c74099722130f39315cad
+    type: compile
+    version: 2.1.0.RELEASE
+  - labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.boot.spring-boot-starter-web
+    prefix: m2/repository/org/springframework/boot/spring-boot-starter-web/2.1.0.RELEASE
+    resolvedIdentifier: 92b4b0c33588a1556d76529149fb7203efc3dd64
+    type: compile
+    version: 2.1.0.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-aop
+    prefix: m2/repository/org/springframework/spring-aop/5.1.2.RELEASE
+    resolvedIdentifier: ddc7d2e3b4e3d23e29b9939b64bc3dce091fff6f
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-beans
+    prefix: m2/repository/org/springframework/spring-beans/5.1.2.RELEASE
+    resolvedIdentifier: 1f8be66e7a7e060693d61a504d9c31185f5544aa
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-context
+    prefix: m2/repository/org/springframework/spring-context/5.1.2.RELEASE
+    resolvedIdentifier: 4faf7e59461f30e60d26977975a78ba181c78487
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-core
+    prefix: m2/repository/org/springframework/spring-core/5.1.2.RELEASE
+    resolvedIdentifier: e2310971343df90581d173006226671e574e1df1
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-expression
+    prefix: m2/repository/org/springframework/spring-expression/5.1.2.RELEASE
+    resolvedIdentifier: 7f45b616d59579e07c44ae01b5fc5821db19b322
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-jcl
+    prefix: m2/repository/org/springframework/spring-jcl/5.1.2.RELEASE
+    resolvedIdentifier: b35f3aeb0afcc782ec7a1c1f1ab8325fb7a9e223
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-web
+    prefix: m2/repository/org/springframework/spring-web/5.1.2.RELEASE
+    resolvedIdentifier: ed47f5756ab15e223ac5cb4993beb8bfa5adc130
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.springframework.spring-webmvc
+    prefix: m2/repository/org/springframework/spring-webmvc/5.1.2.RELEASE
+    resolvedIdentifier: ee1900a33a5376cb0b9514cc29db80aa6bf7c291
+    type: compile
+    version: 5.1.2.RELEASE
+  - indirect: true
+    labels:
+    - konveyor.io/dep-source=open-source
+    - konveyor.io/language=java
+    name: org.yaml.snakeyaml
+    prefix: m2/repository/org/yaml/snakeyaml/1.23
+    resolvedIdentifier: 0542a3f938aebd15b1ae655c89344835e502a87d
+    type: runtime
+    version: '1.23'
+  fileURI: pom.xml
+  provider: java

--- a/shared_tests/analysis_book-server/output.yaml
+++ b/shared_tests/analysis_book-server/output.yaml
@@ -1,0 +1,272 @@
+- name: discovery-rules
+  tags:
+  - EJB XML
+  - Java Source
+  - Maven XML
+- description: This ruleset gives hints to migrate from SpringBoot devtools to Quarkus
+  name: quarkus/springboot
+  violations:
+    javaee-pom-to-quarkus-00010:
+      category: mandatory
+      description: Adopt Quarkus BOM
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Use the Quarkus BOM to omit the version of the different Quarkus\
+          \ dependencies. \n Add the following sections to the `pom.xml` file: \n\n\
+          \ ```xml\n <properties> \n <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>\
+          \ \n <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>\
+          \ \n <quarkus.platform.version>3.1.0.Final</quarkus.platform.version>\n\
+          \ </properties> \n <dependencyManagement> \n <dependencies> \n <dependency>\
+          \ \n <groupId>$</groupId> \n <artifactId>$</artifactId> \n <version>$</version>\
+          \ \n <type>pom</type> \n <scope>import</scope> \n </dependency> \n </dependencies>\
+          \ \n </dependencyManagement> \n ```\n Check the latest Quarkus version available\
+          \ from the `Quarkus - Releases` link below."
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+      - title: Quarkus - Releases
+        url: https://quarkus.io/blog/tag/release/
+    javaee-pom-to-quarkus-00020:
+      category: mandatory
+      description: Adopt Quarkus Maven plugin
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Use the Quarkus Maven plugin adding the following sections to the\
+          \ `pom.xml` file: \n\n ```xml\n <properties> \n <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>\
+          \ \n <quarkus.platform.version>3.1.0.Final</quarkus.platform.version>\n\
+          \ </properties> \n <build>\n <plugins>\n <plugin>\n <groupId>$</groupId>\n\
+          \ <artifactId>quarkus-maven-plugin</artifactId>\n <version>$</version>\n\
+          \ <extensions>true</extensions>\n <executions>\n <execution>\n <goals>\n\
+          \ <goal>build</goal>\n <goal>generate-code</goal>\n <goal>generate-code-tests</goal>\n\
+          \ </goals>\n </execution>\n </executions>\n </plugin>\n </plugins>\n </build>\n\
+          \ ```"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+    javaee-pom-to-quarkus-00030:
+      category: mandatory
+      description: Adopt Maven Compiler plugin
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Use the Maven Compiler plugin adding the following sections to the\
+          \ `pom.xml` file: \n\n ```xml\n <properties> \n <compiler-plugin.version>3.10.1</compiler-plugin.version>\n\
+          \ <maven.compiler.release>11</maven.compiler.release>\n </properties> \n\
+          \ <build>\n <plugins>\n <plugin>\n <artifactId>maven-compiler-plugin</artifactId>\n\
+          \ <version>$</version>\n <configuration>\n <compilerArgs>\n <arg>-parameters</arg>\n\
+          \ </compilerArgs>\n </configuration>\n </plugin>\n </plugins>\n </build>\n\
+          \ ```"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+    javaee-pom-to-quarkus-00040:
+      category: mandatory
+      description: Adopt Maven Surefire plugin
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Use the Maven Surefire plugin adding the following sections to the\
+          \ `pom.xml` file: \n\n ```xml\n <properties> \n <surefire-plugin.version>3.0.0</compiler-plugin.version>\n\
+          \ </properties> \n <build>\n <plugins>\n <plugin>\n <artifactId>maven-surefire-plugin</artifactId>\n\
+          \ <version>$</version>\n <configuration>\n <systemPropertyVariables>\n <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>\n\
+          \ <maven.home>$</maven.home>\n </systemPropertyVariables>\n </configuration>\n\
+          \ </plugin>\n </plugins>\n </build>\n ```"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+    javaee-pom-to-quarkus-00050:
+      category: mandatory
+      description: Adopt Maven Failsafe plugin
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Use the Maven Failsafe plugin adding the following sections to the\
+          \ `pom.xml` file: \n\n ```xml\n <properties> \n <surefire-plugin.version>3.0.0</compiler-plugin.version>\n\
+          \ </properties> \n <build>\n <plugins>\n <plugin>\n <artifactId>maven-failsafe-plugin</artifactId>\n\
+          \ <version>$</version>\n <executions>\n <execution>\n <goals>\n <goals>integration-test</goal>\n\
+          \ <goals>verify</goal>\n </goals>\n <configuration>\n <systemPropertyVariables>\n\
+          \ <native.image.path>$/$-runner</native.image.path>\n <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>\n\
+          \ <maven.home>$</maven.home>\n </systemPropertyVariables>\n </configuration>\n\
+          \ </execution>\n </executions>\n </plugin>\n </plugins>\n </build>\n ```"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+    javaee-pom-to-quarkus-00060:
+      category: mandatory
+      description: Add Maven profile to run the Quarkus native build
+      effort: 1
+      incidents:
+      - codeSnip: 5      <modelVersion>4.0.0</modelVersion>
+        lineNumber: 5
+        message: "Leverage a Maven profile to run the Quarkus native build adding\
+          \ the following section to the `pom.xml` file: \n\n ```xml\n <profiles>\n\
+          \ <profile>\n <id>native</id>\n <activation>\n <property>\n <name>native</name>\n\
+          \ </property>\n </activation>\n <properties>\n <skipITs>false</skipITs>\n\
+          \ <quarkus.package.type>native</quarkus.package.type>\n </properties>\n\
+          \ </profile>\n </profiles>\n ```"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=java-ee
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus - Guide;
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven;
+    springboot-annotations-to-quarkus-00000:
+      category: mandatory
+      description: Remove the SpringBoot @SpringBootApplication annotation
+      effort: 1
+      incidents:
+      - codeSnip: 6  @SpringBootApplication
+        lineNumber: 6
+        message: "Remove the SpringBoot @SpringBootApplication annotation.\n\n A Spring\
+          \ Boot application contains a \"main\" class with the @SpringBootApplication\
+          \ annotation. A Quarkus application does not have such a class. Two different\
+          \ alternatives can be followed - either\n to remove the \"main\" class associated\
+          \ with the annotation, or add the `org.springframework.boot:spring-boot-autoconfigure`\
+          \ dependency as an `optional` Maven dependency. An optional dependency \n\
+          \ is available when an application compiles but is not packaged with the\
+          \ application at runtime. Doing this would allow the application to compile\
+          \ without modification, but you\n would also need to maintain a Spring version\
+          \ along with the Quarkus application."
+        uri: src/main/java/com/telran/application/BookServerApp.java
+      labels:
+      - konveyor.io/source=springboot
+      - konveyor.io/target=quarkus
+    springboot-di-to-quarkus-00000:
+      category: potential
+      description: Replace the SpringBoot Dependency Injection artifact with Quarkus
+        'spring-di' extension
+      effort: 1
+      incidents:
+      - codeSnip: 24              <groupId>org.springframework.boot</groupId>
+        lineNumber: 24
+        message: "Replace the SpringBoot Dependency Injection artifact with Quarkus\
+          \ `spring-di` extension\n\n Spring DI is in spring-beans artifact brought\
+          \ transitively by any `org.springframework.boot:spring-boot-*` dependency\n\
+          \ Add Quarkus dependency `io.quarkus:quarkus-spring-di`"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=springboot
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus DI Guide
+        url: https://quarkus.io/guides/spring-di
+    springboot-plugins-to-quarkus-0000:
+      category: mandatory
+      description: Replace the spring-boot-maven-plugin dependency
+      effort: 1
+      incidents:
+      - codeSnip: 14                  <groupId>org.springframework.boot</groupId>
+        lineNumber: 14
+        message: "Replace the `spring-boot-maven-plugin` dependency.\n The `spring-boot-maven-plugin`\
+          \ dependency needs to be replaced with `quarkus-maven-plugin`, so that the\
+          \ application is built with Quarkus, both for running on the JVM and in\
+          \ native mode."
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=springboot
+      - konveyor.io/target=quarkus
+      links:
+      - title: Building Quarkus with maven
+        url: https://quarkus.io/guides/maven-tooling#build-tool-maven
+    springboot-properties-to-quarkus-00000:
+      category: mandatory
+      description: Replace the SpringBoot artifact with Quarkus 'spring-boot-properties'
+        extension
+      effort: 1
+      incidents:
+      - codeSnip: 24              <groupId>org.springframework.boot</groupId>
+        lineNumber: 24
+        message: "Replace the SpringBoot artifact with Quarkus `spring-boot-properties`\
+          \ extension\n\n Spring Configuration Properties is in spring-boot artifact\
+          \ brought transitively by any `org.springframework.boot:spring-boot-*` dependency\n\
+          \ Add Quarkus dependency `io.quarkus:quarkus-spring-boot-properties`"
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=springboot
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus Spring Configuration Properties Guide
+        url: https://quarkus.io/guides/spring-boot-properties
+    springboot-web-to-quarkus-00000:
+      category: mandatory
+      description: Replace the Spring Web artifact with Quarkus 'spring-web' extension
+      effort: 1
+      incidents:
+      - codeSnip: 24              <groupId>org.springframework.boot</groupId>
+        lineNumber: 24
+        message: "Replace the Spring Web artifact with Quarkus `spring-web` extension\n\
+          \n Spring Web is a spring-web artifact brought transitively by any `org.springframework:spring-web*`\
+          \ dependency \n Add Quarkus dependency `io.quarkus:quarkus-spring-web` \n\
+          \ \n Starting with Quarkus version 2.5, the underlying JAX-RS engine must\
+          \ be chosen. For performance reasons,\n the `quarkus-resteasy-reactive-jackson`\
+          \ dependency should be used."
+        uri: pom.xml
+      labels:
+      - konveyor.io/source=springboot
+      - konveyor.io/target=quarkus
+      links:
+      - title: Quarkus Migration Guide 2.5
+        url: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.5#spring-web
+      - title: Quarkus Spring Web Guide
+        url: https://quarkus.io/guides/spring-web
+- description: This ruleset provides analysis of logging libraries.
+  name: technology-usage
+  tags:
+  - Bean=EJB XML
+  - Configuration Management=Spring Boot Auto-configuration
+  - Configuration Management=Spring Boot Component Scan
+  - Configuration Management=Spring Boot Configuration
+  - Connect=EJB XML
+  - Embedded framework - Spring DI
+  - Embedded framework - Spring MVC
+  - Embedded framework - Spring Web
+  - Embedded=Spring Boot Auto-configuration
+  - Embedded=Spring Boot Component Scan
+  - Embedded=Spring Boot Configuration
+  - Embedded=Spring DI
+  - Embedded=Spring MVC
+  - Embedded=Spring Web
+  - Execute=Spring DI
+  - Inversion of Control=Spring DI
+  - Java EE=EJB XML
+  - MVC=Spring MVC
+  - Spring Boot Auto-configuration
+  - Spring Boot Component Scan
+  - Spring Boot Configuration
+  - Spring DI
+  - Spring MVC
+  - Spring Web
+  - Sustain=Spring Boot Auto-configuration
+  - Sustain=Spring Boot Component Scan
+  - Sustain=Spring Boot Configuration
+  - View=Spring MVC
+  - View=Spring Web
+  - Web=Spring Web

--- a/shared_tests/analysis_book-server/tc.yaml
+++ b/shared_tests/analysis_book-server/tc.yaml
@@ -1,0 +1,9 @@
+---
+description: book-store basic analysis
+input: https://github.com/ibraginsky/book-server
+sources:
+- java-ee
+- springboot
+targets:
+- linux
+- quarkus


### PR DESCRIPTION
Adding shared test cases definition that might be used across Konveyor components to keep consistent analysis results.

Initial implementation of the shared analysis tests should follow in CLI and API tests.

Starting with book-server application analysis.

Related to: https://github.com/konveyor/enhancements/pull/228