### PR TITLE
Update shared test book-server with cloudreadiness

### DIFF
--- a/shared_tests/analysis_book-server/output.yaml
+++ b/shared_tests/analysis_book-server/output.yaml
@@ -1,3 +1,107 @@
+- description: This ruleset detects logging configurations that may be problematic
+    when migrating an application to a cloud environment.
+  name: cloud-readiness
+  violations:
+    local-storage-00001:
+      category: mandatory
+      description: File system - Java IO
+      effort: 1
+      incidents:
+      - codeSnip: 14          File file = new File(fileName);
+        lineNumber: 14
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      - codeSnip: 17          PrintWriter pw = new PrintWriter(new FileWriter(file));
+        lineNumber: 17
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      - codeSnip: 23              pw.println(mapper.writeValueAsString(Book.getRandomBook()));
+        lineNumber: 23
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      - codeSnip: 29          File file = new File(filename);
+        lineNumber: 29
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      - codeSnip: 32          BufferedReader br = new BufferedReader(new FileReader(file));
+        lineNumber: 32
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      - codeSnip: 40              library.put(book.getISBN(), book);
+        lineNumber: 40
+        message: "An application running inside a container could lose access to a\
+          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
+          \ depend on the function of the file in local storage:\n\n * Logging: Log\
+          \ to standard output and use a centralized log collector to analyze the\
+          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
+          \ configuration settings in environment variables so that they can be updated\
+          \ without code changes.\n * Data storage: Use a database backing service\
+          \ for relational data or use a persistent data storage system.\n * Temporary\
+          \ data storage: Use the file system of a running container as a brief, single-transaction\
+          \ cache."
+        uri: src/main/java/com/telran/application/model/BookModel.java
+      labels:
+      - konveyor.io/source
+      - konveyor.io/target=cloud-readiness
+      - storage
+      links:
+      - title: 'OpenShift Container Platform: Input secrets and ConfigMaps'
+        url: https://docs.openshift.com/container-platform/4.5/builds/creating-build-inputs.html#builds-input-secrets-configmaps_creating-build-inputs
+      - title: 'OpenShift Container Platform: Understanding cluster logging'
+        url: https://docs.openshift.com/container-platform/4.5/logging/cluster-logging.html
+      - title: 'OpenShift Container Platform: Understanding persistent storage'
+        url: https://docs.openshift.com/container-platform/4.5/storage/understanding-persistent-storage.html
+      - title: 'Twelve-Factor App: Backing services'
+        url: https://12factor.net/backing-services
+      - title: 'Twelve-Factor App: Config'
+        url: https://12factor.net/config
+      - title: 'Twelve-Factor App: Logs'
+        url: https://12factor.net/logs
 - name: discovery-rules
   tags:
   - EJB XML

--- a/shared_tests/analysis_book-server/tc.yaml
+++ b/shared_tests/analysis_book-server/tc.yaml
@@ -5,5 +5,6 @@ sources:
 - java-ee
 - springboot
 targets:
+- cloud-readiness
 - linux
 - quarkus


### PR DESCRIPTION
Based on discussion with Igor, adding cloud-readiness target for book-server application analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "cloud-readiness" ruleset to identify problematic local file system usage in Java applications, providing detailed guidance and external resources for cloud migration.
  * Added "cloud-readiness" as a new target category in configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->