### PR TITLE
Revert "Adding test dependency"

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -351,7 +351,6 @@ jobs:
       - name: Install test dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-          go install github.com/jstemmer/go-junit-report/v2@latest
         working-directory: go-konveyor-tests
 
       - name: Build and run golang API tests

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -281,7 +281,6 @@ jobs:
       - name: Install test dependencies
         run: |
           go install github.com/onsi/ginkgo/v2/ginkgo
-          go install github.com/jstemmer/go-junit-report/v2@latest
         working-directory: go-konveyor-tests
 
       - name: Build and run golang API tests


### PR DESCRIPTION
Reverts konveyor/ci#111
No need after https://github.com/konveyor/go-konveyor-tests/pull/324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Chores
  - Simplified CI by removing an unused test reporting dependency, reducing build complexity and maintenance overhead; primary test tool remains unchanged.

- Tests
  - Test execution and results unchanged; only dependency installation was simplified, with no impact on coverage or reported outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->