### PR TITLE
Fix analyzer logs upload in global-ci-bundle.yml

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -375,7 +375,7 @@ jobs:
         with:
           name: analysis-tests-output
           include-hidden-files: true
-          path: /home/runner/work/ci/ci/go-konveyor-tests/analysis/tmp_output
+          path: /home/runner/work/ci/ci/go-konveyor-tests/tmp_output
 
   e2e-ui-integration-tests:
     needs: check-images


### PR DESCRIPTION
E2E API tests are executed with `working-directory: go-konveyor-tests`, adding that path also to upload analysis logs step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to upload test artifacts from the checked-out test workspace, improving consistency of archived test outputs. No user-facing changes.

* **Tests**
  * Adjusted artifact upload source for end-to-end API integration tests to ensure analysis outputs are reliably captured for debugging and traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->