### PR TITLE
Use repository branch instead of tag

### DIFF
--- a/shared_tests/test_cases.yml
+++ b/shared_tests/test_cases.yml
@@ -4,7 +4,7 @@ book-server_deps:
   application:
     name: book-server
     repository:
-      url: https://github.com/mguetta1/book-server
+      url: https://github.com/migtools/book-server
       kind: git
       branch: v0.0.1
   filename: book-server
@@ -22,7 +22,7 @@ book-server_source:
   application:
     name: book-server
     repository:
-      url: https://github.com/mguetta1/book-server
+      url: https://github.com/migtools/book-server
       kind: git
       branch: v0.0.1
   filename: book-server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched dependency references from a tag to a branch for version v0.0.1 in test configuration.

* **Chores**
  * Maintenance updates to dependency configuration.
  * No functional or user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->