### PR TITLE
Add release-0.8 nightly and update readme

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -344,7 +344,20 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: start minikube
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.7
+        if: "${{ startsWith(inputs.operator_tag, 'v0.7') }}"
+        with:
+          memory: 'max'
+          cpus: 'max'
+      - name: start minikube
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.8
+        if: "${{ startsWith(inputs.operator_tag, 'v0.8') }}"
+        with:
+          memory: 'max'
+          cpus: 'max'
+      - name: start minikube
         uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
+        if: "${{ startsWith(inputs.operator_tag, 'latest') }}"
         with:
           memory: 'max'
           cpus: 'max'

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -206,6 +206,12 @@ jobs:
           memory: 'max'
           cpus: 'max'
       - name: start minikube
+        uses: konveyor/tackle2-operator/.github/actions/start-minikube@release-0.8
+        if: "${{ startsWith(inputs.operator_tag, 'v0.8') }}"
+        with:
+          memory: 'max'
+          cpus: 'max'
+      - name: start minikube
         uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
         if: "${{ startsWith(inputs.operator_tag, 'latest') }}"
         with:
@@ -236,6 +242,17 @@ jobs:
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.7
         if: "${{ startsWith(inputs.operator_tag, 'v0.7') }}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.8
+        if: "${{ startsWith(inputs.operator_tag, 'v0.8') }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
@@ -356,6 +373,17 @@ jobs:
       - name: install konveyor
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.7
         if: "${{ startsWith(inputs.operator_tag, 'v0.7') }}"
+        with:
+          operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
+          hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
+          ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
+          addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          image-pull-policy: IfNotPresent
+          analyzer-container-memory: 0
+          analyzer-container-cpu: 0
+      - name: install konveyor
+        uses: konveyor/tackle2-operator/.github/actions/install-tackle@release-0.8
+        if: "${{ startsWith(inputs.operator_tag, 'v0.8') }}"
         with:
           operator-bundle-image: "quay.io/konveyor/tackle2-operator-bundle:${{ inputs.operator_tag }}"
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"

--- a/.github/workflows/nightly-release-0.8.yaml
+++ b/.github/workflows/nightly-release-0.8.yaml
@@ -1,0 +1,35 @@
+name: Run Konveyor release-0.8 nightly tests
+
+on:
+  schedule:
+    - cron: "35 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  release-0_8-nightly:
+    uses: ./.github/workflows/global-ci.yml
+    with:
+      tag: release-0.8
+      operator_tag: v0.8.0-beta.4
+      api_tests_ref: release-0.8
+      run_api_tests: true
+      ui_tests_ref: release-0.8
+      # Disabled while we wait for stability
+      run_ui_tests: false
+  report_failure:
+    needs: release-0_8-nightly
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send failure data to Slack workflow
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "test": "E2E API",
+              "branch": "release-0.8",
+              "note": "Failed run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Branch | Konveyor | CLI
 --|--|--
 **main** | [![Run Konveyor main nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-main.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-main.yaml) | [![Nightly CLI test for main](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-latest.yaml/badge.svg)](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-latest.yaml)
+**release-0.8** | [![Run Konveyor release-0.8 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.8.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.8.yaml) | [![Nightly CLI test for release-0.8](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-release08.yaml/badge.svg)](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-release08.yaml)
 **release-0.7** | [![Run Konveyor release-0.7 nightly tests](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.7.yaml/badge.svg?branch=main)](https://github.com/konveyor/ci/actions/workflows/nightly-release-0.7.yaml) | [![Nightly CLI test for release-0.7](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-release07.yaml/badge.svg)](https://github.com/konveyor-ecosystem/kantra-cli-tests/actions/workflows/nightly-main-release07.yaml)
 
 ## Repositories status


### PR DESCRIPTION
Related to https://github.com/konveyor/ci/issues/122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added a nightly test workflow for release-0.8 with scheduled and manual triggers, including failure reporting to Slack; UI tests are temporarily disabled while stabilizing.
  - Enhanced CI pipelines to add conditional support for release-0.8 test paths across API and UI end-to-end workflows, preserving existing release flows.

- Documentation
  - Updated the README with a new release-0.8 row and badges/links for Konveyor nightly tests and Nightly CLI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->