### PR TITLE
Update global-ci-bundle.yml with disable_maven_search default CR

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -70,7 +70,7 @@ on:
           Full JSON encoded string representing the Tackle resource to be created.
         type: string
         required: false
-        default: '{"kind":"Tackle","apiVersion":"tackle.konveyor.io/v1alpha1","metadata":{"name":"tackle"},"spec":{"image_pull_policy":"IfNotPresent","analyzer_container_memory":0,"analyzer_container_cpu":0,"feature_auth_required":false}}'
+        default: '{"kind":"Tackle","apiVersion":"tackle.konveyor.io/v1alpha1","metadata":{"name":"tackle"},"spec":{"image_pull_policy":"IfNotPresent","analyzer_container_memory":0,"analyzer_container_cpu":0,"feature_auth_required":false,"disable_maven_search": true}}'
       run_api_tests:
         description: |
           A flag that determines whether the API tests should be run or not

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -70,7 +70,17 @@ on:
           Full JSON encoded string representing the Tackle resource to be created.
         type: string
         required: false
-        default: '{"kind":"Tackle","apiVersion":"tackle.konveyor.io/v1alpha1","metadata":{"name":"tackle"},"spec":{"image_pull_policy":"IfNotPresent","analyzer_container_memory":0,"analyzer_container_cpu":0,"feature_auth_required":false,"disable_maven_search": true}}'
+        default: |
+          kind: Tackle
+          apiVersion: tackle.konveyor.io/v1alpha1
+          metadata:
+            name: tackle
+          spec:
+            image_pull_policy: IfNotPresent
+            analyzer_container_memory: 0
+            analyzer_container_cpu: 0
+            feature_auth_required: false
+            disable_maven_search: true
       run_api_tests:
         description: |
           A flag that determines whether the API tests should be run or not


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated default CI configuration to disable Maven search by default in Tackle settings.
  - Adjusted workflow input defaults to include the new configuration field.
  - No changes to workflow control flow or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->