### PR TITLE
:test_tube: Update bookserver rules

### DIFF
--- a/shared_tests/book-server_deps/output.yaml
+++ b/shared_tests/book-server_deps/output.yaml
@@ -33,19 +33,6 @@
           \ data storage: Use the file system of a running container as a brief, single-transaction\
           \ cache."
         uri: src/main/java/com/telran/application/model/BookModel.java
-      - codeSnip: 23              pw.println(mapper.writeValueAsString(Book.getRandomBook()));
-        lineNumber: 23
-        message: "An application running inside a container could lose access to a\
-          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
-          \ depend on the function of the file in local storage:\n\n * Logging: Log\
-          \ to standard output and use a centralized log collector to analyze the\
-          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
-          \ configuration settings in environment variables so that they can be updated\
-          \ without code changes.\n * Data storage: Use a database backing service\
-          \ for relational data or use a persistent data storage system.\n * Temporary\
-          \ data storage: Use the file system of a running container as a brief, single-transaction\
-          \ cache."
-        uri: src/main/java/com/telran/application/model/BookModel.java
       - codeSnip: 29          File file = new File(filename);
         lineNumber: 29
         message: "An application running inside a container could lose access to a\
@@ -61,19 +48,6 @@
         uri: src/main/java/com/telran/application/model/BookModel.java
       - codeSnip: 32          BufferedReader br = new BufferedReader(new FileReader(file));
         lineNumber: 32
-        message: "An application running inside a container could lose access to a\
-          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
-          \ depend on the function of the file in local storage:\n\n * Logging: Log\
-          \ to standard output and use a centralized log collector to analyze the\
-          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
-          \ configuration settings in environment variables so that they can be updated\
-          \ without code changes.\n * Data storage: Use a database backing service\
-          \ for relational data or use a persistent data storage system.\n * Temporary\
-          \ data storage: Use the file system of a running container as a brief, single-transaction\
-          \ cache."
-        uri: src/main/java/com/telran/application/model/BookModel.java
-      - codeSnip: 40              library.put(book.getISBN(), book);
-        lineNumber: 40
         message: "An application running inside a container could lose access to a\
           \ file in local storage.\n\n Recommendations\n\n The following recommendations\
           \ depend on the function of the file in local storage:\n\n * Logging: Log\

--- a/shared_tests/book-server_source/output.yaml
+++ b/shared_tests/book-server_source/output.yaml
@@ -33,19 +33,6 @@
           \ data storage: Use the file system of a running container as a brief, single-transaction\
           \ cache."
         uri: src/main/java/com/telran/application/model/BookModel.java
-      - codeSnip: 23              pw.println(mapper.writeValueAsString(Book.getRandomBook()));
-        lineNumber: 23
-        message: "An application running inside a container could lose access to a\
-          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
-          \ depend on the function of the file in local storage:\n\n * Logging: Log\
-          \ to standard output and use a centralized log collector to analyze the\
-          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
-          \ configuration settings in environment variables so that they can be updated\
-          \ without code changes.\n * Data storage: Use a database backing service\
-          \ for relational data or use a persistent data storage system.\n * Temporary\
-          \ data storage: Use the file system of a running container as a brief, single-transaction\
-          \ cache."
-        uri: src/main/java/com/telran/application/model/BookModel.java
       - codeSnip: 29          File file = new File(filename);
         lineNumber: 29
         message: "An application running inside a container could lose access to a\
@@ -61,19 +48,6 @@
         uri: src/main/java/com/telran/application/model/BookModel.java
       - codeSnip: 32          BufferedReader br = new BufferedReader(new FileReader(file));
         lineNumber: 32
-        message: "An application running inside a container could lose access to a\
-          \ file in local storage.\n\n Recommendations\n\n The following recommendations\
-          \ depend on the function of the file in local storage:\n\n * Logging: Log\
-          \ to standard output and use a centralized log collector to analyze the\
-          \ logs.\n * Caching: Use a cache backing service.\n * Configuration: Store\
-          \ configuration settings in environment variables so that they can be updated\
-          \ without code changes.\n * Data storage: Use a database backing service\
-          \ for relational data or use a persistent data storage system.\n * Temporary\
-          \ data storage: Use the file system of a running container as a brief, single-transaction\
-          \ cache."
-        uri: src/main/java/com/telran/application/model/BookModel.java
-      - codeSnip: 40              library.put(book.getISBN(), book);
-        lineNumber: 40
         message: "An application running inside a container could lose access to a\
           \ file in local storage.\n\n Recommendations\n\n The following recommendations\
           \ depend on the function of the file in local storage:\n\n * Logging: Log\


### PR DESCRIPTION
Resolves #127 

According to the rule definition, the removed incidents should be matching in analyses.

```yaml
  ruleID: local-storage-00001
  when:
    or:
    - java.referenced:
        location: CONSTRUCTOR_CALL
        pattern: java.io.(FileWriter|FileReader|PrintStream|File|PrintWriter|RandomAccessFile)*
    - java.referenced:
        location: CONSTRUCTOR_CALL
        pattern: java.util.zip.ZipFile*
    - java.referenced:
        location: METHOD_CALL
        pattern: java.io.File.createTempFile
    - java.referenced:
        location: METHOD_CALL
        pattern: java.nio.file.Paths.get*
```

Tested on latest konveyor and confirmed it doesn't detect those incidents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Removed two obsolete incident entries from shared test outputs for book-server dependencies and source, reducing noise in cloud-readiness reports.
  - No functional or user-facing changes.

- Chores
  - Synchronized test artifacts to align with current expectations and improve clarity of test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->