### PR TITLE
Update operator tag to v0.8.0 in nightly release

### DIFF
--- a/.github/workflows/nightly-release-0.8.yaml
+++ b/.github/workflows/nightly-release-0.8.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       tag: release-0.8
-      operator_tag: v0.8.0-beta.4
+      operator_tag: v0.8.0
       api_tests_ref: release-0.8
       run_api_tests: true
       ui_tests_ref: release-0.8


### PR DESCRIPTION
0.8 nightly operator tag update to released v0.8.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure configuration for the 0.8 release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->