### PR TITLE
:bug: Pass java-provider-image tag to prevent install-tackle from using latest

### DIFF
--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -258,6 +258,7 @@ jobs:
           hub-image: "quay.io/konveyor/tackle2-hub:${{ inputs.tag }}"
           ui-image: "quay.io/konveyor/tackle2-ui:${{ inputs.tag }}"
           addon-analyzer-image: "quay.io/konveyor/tackle2-addon-analyzer:${{ inputs.tag }}"
+          java-provider-image: "quay.io/konveyor/java-external-provider:${{ inputs.tag }}"
           image-pull-policy: IfNotPresent
           analyzer-container-memory: 0
           analyzer-container-cpu: 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to support deploying a java external provider image across both release-0.8 and main branches, expanding the deployment capabilities of the installation workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->