### PR TITLE
:bug: Operator bundle should be release-0.8

### DIFF
--- a/.github/workflows/nightly-release-0.8.yaml
+++ b/.github/workflows/nightly-release-0.8.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       tag: release-0.8
-      operator_tag: v0.8.1-alpha.2
+      operator_tag: release-0.8
       api_tests_ref: release-0.8
       run_api_tests: true
       ui_tests_ref: release-0.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly release workflow configuration to use a different operator image tag for release builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->