### PR TITLE
Update global CI workflows to run UI tests from tackle2-ui repository

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -472,11 +472,11 @@ jobs:
             -n konveyor-tackle \
             ingress/tackle \
             --timeout=600s \
-            --for=jsonpath='{.status.loadBalancer.ingress[0]}'
+            --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 
-          minikube_ip=$(minikube ip)
-          echo "ingress is ready at: ${minikube_ip}"
-          echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
+          ingress_ip=$(kubectl get ingress/tackle -n konveyor-tackle -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "ingress is ready at: ${ingress_ip}"
+          echo "UI_URL=https://${ingress_ip}" >>$GITHUB_ENV
       # end DRY
 
       - name: Extract pull request number from inputs or PR description

--- a/.github/workflows/global-ci.yml
+++ b/.github/workflows/global-ci.yml
@@ -408,11 +408,11 @@ jobs:
             -n konveyor-tackle \
             ingress/tackle \
             --timeout=600s \
-            --for=jsonpath='{.status.loadBalancer.ingress[0]}'
+            --for=jsonpath='{.status.loadBalancer.ingress[0].ip}'
 
-          minikube_ip=$(minikube ip)
-          echo "ingress is ready at: ${minikube_ip}"
-          echo "UI_URL=https://${minikube_ip}" >>$GITHUB_ENV
+          ingress_ip=$(kubectl get ingress/tackle -n konveyor-tackle -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          echo "ingress is ready at: ${ingress_ip}"
+          echo "UI_URL=https://${ingress_ip}" >>$GITHUB_ENV
       # end DRY
 
       - name: Extract pull request number from inputs or PR description


### PR DESCRIPTION
Change summary:
  - Use a new action to run UI tests from tackle2-ui repository

Ref: https://github.com/konveyor/tackle2-ui/pull/2786
Ref: https://github.com/konveyor/tackle2-ui/issues/2667
Ref: https://github.com/konveyor/tackle2-ui/pull/2699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated CI and UI test execution into a single streamlined flow, removing redundant steps and artifact uploads.
  * Simplified service readiness detection and directly derived the app URL from the ingress, improving test startup reliability.
  * Centralized UI test reference handling with PR-number fallback (or configured input) to ensure consistent test targeting and environment propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->