### PR TITLE
:bug: removing references to my fork's actions/workflows

### DIFF
--- a/.github/workflows/build-nightly-images.yaml
+++ b/.github/workflows/build-nightly-images.yaml
@@ -32,6 +32,11 @@ jobs:
         with:
           repository: ${{ matrix.image.repo }}
           ref: ${{ inputs.branch }}
+      
+      - name: Setup golang
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25' 
 
       - name: Update go mod to the branch
         id: go_mod

--- a/.github/workflows/build-nightly-images.yaml
+++ b/.github/workflows/build-nightly-images.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: build image
         id: build-image
-        uses: shawn-hurley/ci/build-image@main
+        uses: konveyor/ci/build-image@main
         with:
           repo: ${{ matrix.image.repo }}
           ref: ${{ inputs.branch }}

--- a/.github/workflows/nightly-koncur.yaml
+++ b/.github/workflows/nightly-koncur.yaml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - name: Run Koncur Testing
         id: koncur-test
-        uses: shawn-hurley/ci/koncur-kantra@main
+        uses: konveyor/ci/koncur-kantra@main
         with:
           os: ${{ matrix.os.os }}
           image_pattern: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/nightly workflows to use a different build and test provider and to set the Go toolchain to 1.25.
  * Preserved existing inputs and overall build/test behavior.

* **Impact**
  * No user-visible changes; existing functionality and build outcomes remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->