### PR TITLE
:bug: Build only generic provider for release-0.9

### DIFF
--- a/.github/workflows/nightly-koncur-0.9.yaml
+++ b/.github/workflows/nightly-koncur-0.9.yaml
@@ -58,9 +58,9 @@ jobs:
         id: prepare
         shell: bash
         run: |
-          
+
           pip install -r scripts/requirements.txt
-          python scripts/parse_matrix_config.py .github/workflows/nightly-matrix-config.yaml -t ${{ needs.nightly-tag.outputs.tag }} -b ${{ inputs.branch || 'release-0.9' }} out
+          python scripts/parse_matrix_config.py .github/workflows/nightly-matrix-config-0.9.yaml -t ${{ needs.nightly-tag.outputs.tag }} -b ${{ inputs.branch || 'release-0.9' }} out
           matrix_0=$(cat out/level_0.json)
           matrix_1=$(cat out/level_1.json)
           matrix_2=$(cat out/level_2.json)

--- a/.github/workflows/nightly-matrix-config-0.9.yaml
+++ b/.github/workflows/nightly-matrix-config-0.9.yaml
@@ -1,0 +1,77 @@
+config:
+  - repo: "konveyor/tackle2-ui"
+    image: "quay.io/konveyor/tackle2-ui"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+
+  - repo: "konveyor/tackle2-addon-platform"
+    image: "quay.io/konveyor/tackle2-addon-platform"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+
+  - repo: "konveyor/kai"
+    image: "quay.io/konveyor/kai-solution-server"
+    dockerfile_path: "./kai_mcp_solution_server/tools/deploy/Containerfile"
+    context_path: "./kai_mcp_solution_server"
+
+  - repo: "konveyor/tackle2-addon-discovery"
+    image: "quay.io/konveyor/tackle2-addon-discovery"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+
+  - repo: "konveyor/analyzer-lsp"
+    image: "quay.io/konveyor/analyzer-lsp"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+    dependent_jobs:
+      - repo: "konveyor/tackle2-addon-analyzer"
+        image: "quay.io/konveyor/tackle2-addon-analyzer"
+        dockerfile_path: "Dockerfile"
+        context_path: "."
+        go_mod_update:
+          - "github.com/konveyor/analyzer-lsp@BRANCH_PLACEHOLDER"
+
+  # For release-0.9, only the generic provider exists (no language-specific providers yet)
+  - repo: "konveyor/analyzer-lsp"
+    image: "quay.io/konveyor/generic-external-provider"
+    dockerfile_path: "./external-providers/generic-external-provider/Dockerfile"
+    context_path: "."
+    go_mod_update:
+      - "github.com/konveyor/analyzer-lsp@BRANCH_PLACEHOLDER"
+    go_mod_directory: "./external-providers/generic-external-provider"
+    dependent_jobs:
+      # NOTE that the kantra actual requirements are more than this
+      # but this should be changed eventually so not going to deal with it
+      # right now
+      - repo: "konveyor/kantra"
+        image: "quay.io/konveyor/kantra"
+        dockerfile_path: "Dockerfile"
+        context_path: "."
+        go_mod_update:
+          - "github.com/konveyor/analyzer-lsp@BRANCH_PLACEHOLDER"
+          - "github.com/konveyor/analyzer-lsp/external-providers/java-external-provider@BRANCH_PLACEHOLDER"
+          ## There are no release branches for asset-generation, so make sure we use the latest code
+          - "github.com/konveyor/asset-generation@main"
+
+  - repo: "konveyor/java-analyzer-bundle"
+    image: "quay.io/konveyor/jdtls-server-base"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+
+  - repo: "konveyor/static-report"
+    image: "quay.io/konveyor/static-report"
+    dockerfile_path: "Dockerfile"
+    context_path: "."
+    dependent_jobs:
+      - repo: "konveyor/tackle2-hub"
+        image: "quay.io/konveyor/tackle2-hub"
+        dockerfile_path: "Dockerfile"
+        context_path: "."
+        args: "SEED_BRANCH=BRANCH_PLACEHOLDER"
+        go_mod_update:
+          - "github.com/konveyor/tackle2-seed@BRANCH_PLACEHOLDER"
+
+  - repo: "konveyor/c-sharp-analyzer-provider"
+    image: "quay.io/konveyor/c-sharp-provider"
+    dockerfile_path: "Dockerfile"
+    context_path: "."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a dedicated nightly build matrix configuration for the 0.9 release, enabling automated building and testing of release-specific components as part of the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->