### PR TITLE
:bug: Do not build parent images if not needed

### DIFF
--- a/scripts/parse_matrix_config.py
+++ b/scripts/parse_matrix_config.py
@@ -296,8 +296,10 @@ def organize_by_levels(
         if matches or include:
             job_copy = {k: v for k, v in job.items() if k != "dependent_jobs"}
 
-            # Add base_image field for dependent jobs
-            if parent_image:
+            # Add base_image field for dependent jobs only if parent was included
+            # If include=True, it means the parent matched and will be built
+            # If include=False, the parent is skipped, so use nightly image instead
+            if parent_image and include:
                 parent_image = parent_image.replace("/", "_")
                 if base_image_tag:
                     job_copy["base_image"] = f"{parent_image}--{base_image_tag}"


### PR DESCRIPTION
See [this problem](https://github.com/konveyor/kantra/actions/runs/25371086945/job/74394547558?pr=812) in kantra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected job dependency configuration handling when applying repository filters. Dependent jobs now properly manage image settings based on parent job inclusion, ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->