### PR TITLE
Add koncur PR ref extraction from PR description

### DIFF
--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -55,3 +55,5 @@ jobs:
       artifact: test-images
       run_api_tests: true
       run_ui_tests: true
+      run_koncur_hub_tests: true
+      run_koncur_kantra_tests: true

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -262,6 +262,7 @@ env:
   operator_bundle: ttl.sh/konveyor-operator-bundle-${{ github.sha }}:4h
   KANTRA_INPUT: ${{ inputs.kantra }}
   BASE_TAG_INPUT: ${{ inputs.base_tag }}
+  KONCUR_REF_INPUT: ${{ inputs.koncur_ref }}
 
 jobs:
   check-images:
@@ -477,7 +478,7 @@ jobs:
         run: |
           PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[K|k]oncur [P|p][R|r]:\s*\K\d+' || true)
           [ -z "$PULL_REQUEST_NUMBER" ] \
-            && KONCUR_REF=${{ inputs.koncur_ref }} \
+            && KONCUR_REF="$KONCUR_REF_INPUT" \
             || KONCUR_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
 
           echo "koncur_ref=${KONCUR_REF}" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -464,8 +464,27 @@ jobs:
           tests_ref: ${{ env.UI_TESTS_REF }}
           base_url: ${{ env.UI_URL }}
 
+  extract-koncur-ref:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.run_koncur_hub_tests || inputs.run_koncur_kantra_tests }}
+    outputs:
+      koncur_ref: ${{ steps.extract.outputs.koncur_ref }}
+    steps:
+      - name: Extract koncur pull request number from inputs or PR description
+        id: extract
+        env:
+          body: ${{ github.event.pull_request.body }}
+        run: |
+          PULL_REQUEST_NUMBER=$(echo ${body} | grep -oP '[K|k]oncur [P|p][R|r]:\s*\K\d+' || true)
+          [ -z "$PULL_REQUEST_NUMBER" ] \
+            && KONCUR_REF=${{ inputs.koncur_ref }} \
+            || KONCUR_REF=refs/pull/$PULL_REQUEST_NUMBER/merge
+
+          echo "koncur_ref=${KONCUR_REF}" >>"$GITHUB_OUTPUT"
+          echo "Using KONCUR_REF \`${KONCUR_REF}\`" >>"$GITHUB_STEP_SUMMARY"
+
   koncur-hub-tests:
-    needs: check-images
+    needs: [check-images, extract-koncur-ref]
     runs-on: ubuntu-latest
     if: ${{ inputs.run_koncur_hub_tests }}
     steps:
@@ -491,7 +510,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: konveyor/koncur
-          ref: ${{ inputs.koncur_ref }}
+          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
           path: koncur
 
       - name: Setup Go
@@ -534,7 +553,7 @@ jobs:
           retention-days: 3
 
   koncur-kantra-tests:
-    needs: check-images
+    needs: [check-images, extract-koncur-ref]
     runs-on: ${{ matrix.runner }}
     if: ${{ inputs.run_koncur_kantra_tests }}
     strategy:
@@ -590,7 +609,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: konveyor/koncur
-          ref: ${{ inputs.koncur_ref }}
+          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
           path: koncur
 
       - name: Setup Go

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ UI tests PR: 233
 
 replacing `233` with the appropriate [konveyor/tackle-ui-tests](https://github.com/konveyor/tackle-ui-tests) pull request number for your tests.
 
+To replace the `koncur-hub-tests` and `koncur-kantra-tests` reference, add the following string to your PR description:
+
+```
+Koncur PR: 233
+```
+
+replacing `233` with the appropriate [konveyor/koncur](https://github.com/konveyor/koncur) pull request number for your tests.
+
 
 ## Code of Conduct
 Refer to Konveyor's Code of Conduct [here](https://github.com/konveyor/community/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Allow specifying a koncur PR number in the PR description using `Koncur PR: <number>` to override the default koncur_ref input. This enables coordinated testing of koncur changes alongside other repository changes.