### PR TITLE
Pin Windows runner to windows-2022

### DIFF
--- a/.github/workflows/e2e-kantra-koncur.yaml
+++ b/.github/workflows/e2e-kantra-koncur.yaml
@@ -39,7 +39,7 @@ jobs:
           - os: "macos"
             runner: "macos-26-large"
           - os: "windows"
-            runner: "windows-latest"
+            runner: "windows-2022"
         exclude:
           - os: 
               os: "macos"

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -501,7 +501,7 @@ jobs:
         id: set-matrix
         run: |
           if [[ "${{ inputs.run_windows_kantra_tests }}" == "true" ]]; then
-            echo 'matrix={"include":[{"os":"linux","runner":"ubuntu-24.04-arm"},{"os":"windows","runner":"windows-latest"}]}' >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"os":"linux","runner":"ubuntu-24.04-arm"},{"os":"windows","runner":"windows-2022"}]}' >> "$GITHUB_OUTPUT"
           else
             echo 'matrix={"include":[{"os":"linux","runner":"ubuntu-24.04-arm"}]}' >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/nightly-koncur-0.9.yaml
+++ b/.github/workflows/nightly-koncur-0.9.yaml
@@ -160,7 +160,7 @@ jobs:
           - os: "macos"
             runner: "macos-26-large"
           - os: "windows"
-            runner: "windows-latest"
+            runner: "windows-2022"
         exclude:
           - os: 
               os: "macos"

--- a/.github/workflows/nightly-koncur.yaml
+++ b/.github/workflows/nightly-koncur.yaml
@@ -160,7 +160,7 @@ jobs:
           - os: "macos"
             runner: "macos-26-large"
           - os: "windows"
-            runner: "windows-latest"
+            runner: "windows-2022"
         exclude:
           - os: 
               os: "macos"

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -143,7 +143,7 @@ runs:
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
     - name: Allow firewall rule
-      if: ${{ !inputs.skip_maven && inputs.os == 'windows-latest' }}
+      if: ${{ !inputs.skip_maven && inputs.os == 'windows' }}
       shell: powershell
       run: |
         $wslAdapter = Get-NetAdapter | Where-Object {$_.Name -like "*WSL*"}
@@ -174,7 +174,7 @@ runs:
         echo "MAVEN_SETTINGS_PATH=$WINDOWS_PATH" >> $GITHUB_ENV
 
     - name: Set maven settings path (*nix)
-      if: ${{ !inputs.skip_maven && inputs.os != 'windows-latest' }}
+      if: ${{ !inputs.skip_maven && inputs.os != 'windows' }}
       shell: bash
       run: |
         mkdir -p "$HOME/.koncur/temp"


### PR DESCRIPTION
For more information, see: https://github.com/actions/runner-images/issues/14017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and nightly test workflows to use the Windows 2022 runner instead of the generic Windows runner.
  * Adjusted Windows-specific setup conditions so Windows and non-Windows steps are applied more consistently across test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->