### PR TITLE
Add retry logic for Chocolatey install on Windows

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -599,7 +599,11 @@ jobs:
         if: ${{ matrix.os == 'windows' }}
         shell: bash
         run: |
-          choco install podman-cli
+          for i in {1..3}; do
+            choco install podman-cli && break
+            echo "Chocolatey install failed (attempt $i/3), retrying in 30s..."
+            sleep 30
+          done
           podman machine init --rootful --memory 10240 --cpus 3
           podman machine start
 

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -36,9 +36,13 @@ runs:
       if: ${{ inputs.os == 'windows' }}
       shell: bash
       run: |
-        choco install podman-cli
+        for i in {1..3}; do
+          choco install podman-cli && break
+          echo "Chocolatey install failed (attempt $i/3), retrying in 30s..."
+          sleep 30
+        done
         podman machine init --rootful --memory 10240 --cpus 3
-        podman machine start 
+        podman machine start
 
     - name: Also add local/bin to windows path and get host wsl ip 
       if: ${{ inputs.os == 'windows' }}


### PR DESCRIPTION
Chocolatey can intermittently fail with 504 Gateway Timeout errors. Add retry loop (3 attempts with 30s delay) to handle transient failures.