### PR TITLE
:bug: Fall back to registry pull when nightly artifacts expire

### DIFF
--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -97,6 +97,7 @@ runs:
       if: ${{ steps.download-artifacts.outcome == 'failure' || steps.download-artifacts.outcome == 'success' }}
       env:
         GH_TOKEN: ${{ github.token }}
+        FALLBACK_TAG: ${{ inputs.ref }}
       shell: bash
       run: |
         ${GITHUB_ACTION_PATH}/check_images.sh

--- a/koncur-kantra/check_images.sh
+++ b/koncur-kantra/check_images.sh
@@ -120,9 +120,57 @@ if [ ${#MISSING[@]} -gt 0 ]; then
     # Check if any downloads succeeded
     if [ $DOWNLOAD_SUCCESS -eq 0 ]; then
         echo ""
-        echo "Error: No artifacts were successfully downloaded (they may have expired)"
+        echo "Warning: No artifacts were successfully downloaded (they may have expired)"
+        echo "Attempting to pull missing images from registry as fallback..."
         rm -rf "$TEMP_DIR"
-        exit 1
+
+        PULL_TAG="${FALLBACK_TAG:-latest}"
+        PULL_SUCCESS=0
+        for img in "${MISSING[@]}"; do
+            echo "Pulling $img:$PULL_TAG..."
+            if podman pull "$img:$PULL_TAG" 2>&1; then
+                echo "Successfully pulled $img:$PULL_TAG"
+                PULL_SUCCESS=1
+
+                NEW_TAG="$img:$PULL_TAG"
+                if [ -n "$FOUND_TAG" ] && [ "$PULL_TAG" != "$FOUND_TAG" ]; then
+                    NEW_TAG="$img:$FOUND_TAG"
+                    echo "Re-tagging to: $NEW_TAG"
+                    podman tag "$img:$PULL_TAG" "$NEW_TAG"
+                fi
+
+                if [[ "$img" =~ $kantra_image_regex ]]; then
+                    echo "RUNNER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+                if [[ "$img" =~ $java_provider_image_regex ]]; then
+                    echo "JAVA_PROVIDER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+                if [[ "$img" =~ $c_sharp_provider_image_regex ]]; then
+                    echo "CSHARP_PROVIDER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+                if [[ "$img" =~ $go_provider_image_regex ]]; then
+                    echo "GO_PROVIDER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+                if [[ "$img" =~ $python_provider_image_regex ]]; then
+                    echo "PYTHON_PROVIDER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+                if [[ "$img" =~ $nodejs_provider_image_regex ]]; then
+                    echo "NODEJS_PROVIDER_IMG=$NEW_TAG" >> $GITHUB_ENV
+                fi
+            else
+                echo "Failed to pull $img:$PULL_TAG"
+            fi
+        done
+
+        if [ $PULL_SUCCESS -eq 0 ]; then
+            echo ""
+            echo "Error: Could not download artifacts or pull images from registry"
+            exit 1
+        fi
+
+        echo ""
+        echo "Registry pull complete. Re-checking images..."
+        exec "$0"
     fi
 
     # Load downloaded images into podman and optionally re-tag

--- a/koncur-kantra/check_images.sh
+++ b/koncur-kantra/check_images.sh
@@ -125,6 +125,13 @@ if [ ${#MISSING[@]} -gt 0 ]; then
         rm -rf "$TEMP_DIR"
 
         PULL_TAG="${FALLBACK_TAG:-latest}"
+        # Strip common git ref prefixes so full refs like refs/heads/main become valid tags
+        PULL_TAG="${PULL_TAG#refs/heads/}"
+        PULL_TAG="${PULL_TAG#refs/tags/}"
+        if [[ "$PULL_TAG" == *"/"* ]]; then
+            echo "Error: FALLBACK_TAG '$PULL_TAG' contains '/' and is not a valid image tag"
+            exit 1
+        fi
         PULL_SUCCESS=0
         for img in "${MISSING[@]}"; do
             echo "Pulling $img:$PULL_TAG..."


### PR DESCRIPTION
## Summary

- When PR CI builds only the tested repo's image (e.g. kantra), provider images (java, go, python, nodejs, c-sharp) are not built
- `check_images.sh` tries to download them from the last successful nightly run, but this fails when artifacts have expired (`retention-days: 1`)
- This causes all koncur tests to fail on kantra PRs with `Error: No artifacts were successfully downloaded`

## Fix

- Pass `FALLBACK_TAG` env var (from the action's `ref` input, defaults to `main`) to `check_images.sh`
- When nightly artifact download fails, fall back to pulling published images from quay.io using the base branch tag (e.g. `main`, `release-0.9`)
- Re-tag pulled images to match the expected tag from the built images
- Set the appropriate provider env vars (`JAVA_PROVIDER_IMG`, etc.)

## Test plan

- [ ] Open a PR on `konveyor/kantra` and verify the koncur tests pass with provider images pulled from quay.io
- [ ] Verify nightly artifact download still works when artifacts haven't expired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-image handling by automatically falling back to pulling images from the container registry when artifact downloads are unavailable.
  * Added support for using a fallback tag, helping image checks continue successfully when the preferred source is missing.
  * Preserved image availability by re-tagging pulled images when needed and setting the appropriate environment values for subsequent steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->