### PR TITLE
:sparkles: Update koncur-tackle-hub action for hub built-in OIDC auth

### DIFF
--- a/.github/workflows/e2e-hub-koncur.yaml
+++ b/.github/workflows/e2e-hub-koncur.yaml
@@ -35,5 +35,5 @@ jobs:
         uses: konveyor/ci/koncur-tackle-hub@main
         with:
           image_pattern: |
-            *{tackle-keycloak-init,tackle2-*,provider}--${{ github.run_id }}
+            *{tackle2-*,provider}--${{ github.run_id }}
           ref: ${{ github.base_ref || inputs.ref || github.ref_name}}

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -38,13 +38,19 @@ on:
         type: string
         required: false
         default: ""
+      # BACKCOMPAT: The operator no longer deploys Keycloak on main (auth moved to
+      # the hub's built-in OIDC provider in tackle2-operator#567), so these inputs
+      # are ignored there. They only matter when base_tag points at a pre-hub-IdP
+      # operator branch (e.g. release-0.9). They stay declared because removing a
+      # workflow_call input hard-errors any caller that still passes it; delete them
+      # once release-0.9 flows are retired and callers are confirmed clean.
       keycloak_sso:
-        description: image uri for keycloak_sso image (ie. quay.io/<namespace>/<image-name>:<tag>)
+        description: "DEPRECATED - ignored on operator main; only meaningful with a pre-hub-IdP operator branch (e.g. release-0.9)"
         type: string
         required: false
         default: ""
       keycloak_init:
-        description: image uri for keycloak_init image (ie. quay.io/<namespace>/<image-name>:<tag>)
+        description: "DEPRECATED - ignored on operator main; only meaningful with a pre-hub-IdP operator branch (e.g. release-0.9)"
         type: string
         required: false
         default: ""
@@ -301,6 +307,8 @@ jobs:
       - name: Check tackle_postgres image exists
         if: ${{ inputs.tackle_postgres != '' }}
         run: docker manifest inspect ${{ inputs.tackle_postgres }}
+      # BACKCOMPAT: keycloak inputs are only set when targeting a pre-hub-IdP
+      # operator branch (e.g. release-0.9); these are no-ops when empty.
       - name: Check keycloak_sso image exists
         if: ${{ inputs.keycloak_sso != '' }}
         run: docker manifest inspect ${{ inputs.keycloak_sso }}
@@ -363,6 +371,7 @@ jobs:
           oauth_proxy: ${{ inputs.oauth_proxy }}
           tackle_hub: ${{ inputs.tackle_hub }}
           tackle_postgres: ${{ inputs.tackle_postgres }}
+          # BACKCOMPAT: only used when a pre-hub-IdP operator (e.g. release-0.9) is targeted
           keycloak_sso: ${{ inputs.keycloak_sso }}
           keycloak_init: ${{ inputs.keycloak_init }}
           tackle_ui: ${{ inputs.tackle_ui }}
@@ -431,6 +440,7 @@ jobs:
           oauth_proxy: ${{ inputs.oauth_proxy }}
           tackle_hub: ${{ inputs.tackle_hub }}
           tackle_postgres: ${{ inputs.tackle_postgres }}
+          # BACKCOMPAT: only used when a pre-hub-IdP operator (e.g. release-0.9) is targeted
           keycloak_sso: ${{ inputs.keycloak_sso }}
           keycloak_init: ${{ inputs.keycloak_init }}
           tackle_ui: ${{ inputs.tackle_ui }}
@@ -521,6 +531,7 @@ jobs:
           oauth_proxy: ${{ inputs.oauth_proxy }}
           tackle_hub: ${{ inputs.tackle_hub }}
           tackle_postgres: ${{ inputs.tackle_postgres }}
+          # BACKCOMPAT: only used when a pre-hub-IdP operator (e.g. release-0.9) is targeted
           keycloak_sso: ${{ inputs.keycloak_sso }}
           keycloak_init: ${{ inputs.keycloak_init }}
           tackle_ui: ${{ inputs.tackle_ui }}

--- a/.github/workflows/nightly-koncur.yaml
+++ b/.github/workflows/nightly-koncur.yaml
@@ -191,7 +191,7 @@ jobs:
         uses: konveyor/ci/koncur-tackle-hub@main
         with:
           image_pattern: |
-            *{tackle-keycloak-init,tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
+            *{tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'main' }}
 
   report_failure:

--- a/koncur-tackle-hub/README.md
+++ b/koncur-tackle-hub/README.md
@@ -195,7 +195,7 @@ Installs the Tackle Hub operator and components using `make hub-install-auth` fr
 
 The environment variables from image loading are passed to the installation, allowing custom images to be used instead of the defaults.
 
-After installation, the action adds `127.0.0.1 tackle.local` to `/etc/hosts` and reconfigures Keycloak to use `https://tackle.local:8443/auth` so Hub is reached at `https://tackle.local:8443/hub` instead of `http://localhost:8080`.
+Auth is provided by the Hub's built-in OIDC provider, which seeds a default `admin`/`admin` user — no separate identity server is deployed. The action reaches the Hub via `kubectl port-forward svc/tackle-hub 8081:8080` at `http://localhost:8081`.
 
 ### 5. Wait for Readiness
 
@@ -206,7 +206,7 @@ Waits for Hub to be fully operational:
      -n konveyor-tackle --timeout=300s
    ```
 
-2. **Ingress readiness**: Polls `https://tackle.local:8443/hub/applications` until it responds (up to 2.5 minutes)
+2. **API readiness**: Polls `http://localhost:8081/applications` with Basic auth (`admin`/`admin`) until it responds (up to 2.5 minutes), and asserts that an unauthenticated request is rejected with `401` (proving auth is enforced)
 
 ### 6. Maven Configuration (Optional)
 
@@ -221,10 +221,9 @@ If `skip_maven: false`:
    ```yaml
    type: tackle-hub
    tackleHub:
-     url: https://tackle.local:8443/hub
+     url: http://localhost:8081
      username: admin
      password: admin
-     insecure: true
      mavenSettings: '/path/to/settings.xml'
    ```
 
@@ -284,14 +283,14 @@ The action automatically outputs this information on failure.
 
 ### Port Forward Fails
 
-**Issue**: Cannot connect to Hub API on `https://tackle.local:8443`
+**Issue**: Cannot connect to Hub API on `http://localhost:8081`
 
-**Solution**: Verify `/etc/hosts` contains `127.0.0.1 tackle.local`, then check ingress and Keycloak:
+**Solution**: Verify the Hub pod is ready and the port-forward is running, then check auth:
 ```bash
-grep tackle.local /etc/hosts
-kubectl get ingress -n konveyor-tackle
-kubectl get pods -n konveyor-tackle -l app.kubernetes.io/name=tackle-keycloak-sso
-curl -skf https://tackle.local:8443/hub/applications
+kubectl get pods -n konveyor-tackle -l app.kubernetes.io/name=tackle-hub
+curl -sf -u admin:admin http://localhost:8081/applications
+# Without credentials this should return 401 (auth enforced):
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/applications
 ```
 
 ### Maven Tests Fail
@@ -369,18 +368,17 @@ See [shared_tests/README.md](../shared_tests/README.md) for more information on 
 │  │  │ Kubernetes Cluster (koncur-test)             │  │ │
 │  │  │                                               │  │ │
 │  │  │  Namespace: konveyor-tackle                   │  │ │
-│  │  │  ├─ tackle-hub (deployment)                   │  │ │
+│  │  │  ├─ tackle-hub (deployment, built-in OIDC)    │  │ │
 │  │  │  ├─ tackle-postgres (statefulset)             │  │ │
-│  │  │  ├─ tackle-keycloak (deployment)              │  │ │
 │  │  │  └─ analyzer-addon (taskgroup/pods)           │  │ │
 │  │  │                                               │  │ │
 │  │  └──────────────────────────────────────────────┘  │ │
 │  │                                                     │ │
-│  │  Ingress: https://tackle.local:8443 (Hub + Keycloak) │ │
+│  │  Port-forward: svc/tackle-hub 8081:8080            │ │
 │  └────────────────────────────────────────────────────┘ │
 │                                                          │
 │  HTTP Server: :8085 (Maven local resources)             │
-│  Koncur CLI → https://tackle.local:8443/hub             │
+│  Koncur CLI → http://localhost:8081 (Basic admin/admin) │
 │                                                          │
 └─────────────────────────────────────────────────────────┘
 ```

--- a/koncur-tackle-hub/action.yml
+++ b/koncur-tackle-hub/action.yml
@@ -91,27 +91,7 @@ runs:
         DISCOVERY_ADDON: ${{ env.DISCOVERY_ADDON }}
         PLATFORM_ADDON: ${{ env.PLATFORM_ADDON }}
         HUB: ${{ env.HUB }}
-        TACKLE_ADMIN_USER: admin
-        TACKLE_ADMIN_PASS: admin
       run: make hub-install-auth
-
-    - name: Configure tackle.local in hosts
-      shell: bash
-      run: |
-        if ! grep -q '[[:space:]]tackle\.local$' /etc/hosts; then
-          echo "127.0.0.1 tackle.local" | sudo tee -a /etc/hosts
-        fi
-        grep tackle.local /etc/hosts
-
-    - name: Configure Keycloak for tackle.local
-      shell: bash
-      run: |
-        kubectl set env deployment/tackle-keycloak-sso -n konveyor-tackle \
-          KC_HOSTNAME=https://tackle.local:8443/auth \
-          KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
-        kubectl patch deployment tackle-keycloak-sso -n konveyor-tackle --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": ["-Djgroups.dns.query=mta-kc-discovery.openshift-mta", "--verbose", "start", "--hostname=https://tackle.local:8443/auth", "--hostname-backchannel-dynamic=true"]}]'
-        kubectl rollout status deployment/tackle-keycloak-sso -n konveyor-tackle --timeout=180s
-        kubectl rollout status deployment/tackle-hub -n konveyor-tackle --timeout=120s
 
     - name: Wait for Hub readiness
       shell: bash
@@ -119,23 +99,36 @@ runs:
         echo "Waiting for all Tackle Hub pods to be ready..."
         kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tackle-hub \
           -n konveyor-tackle --timeout=300s
-        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tackle-keycloak-sso \
-          -n konveyor-tackle --timeout=300s
+
+    - name: Start port-forward
+      shell: bash
+      run: make hub-forward &
 
     - name: Wait for Hub API (auth)
       shell: bash
       run: |
-        echo "Checking Hub API availability via ingress..."
+        echo "Checking Hub API availability via port-forward..."
+        ready=false
         for i in $(seq 1 30); do
-          if curl -skf https://tackle.local:8443/hub/applications > /dev/null 2>&1; then
+          if curl -sf -u admin:admin http://localhost:8081/applications > /dev/null 2>&1; then
             echo "Hub API is ready"
-            exit 0
+            ready=true
+            break
           fi
           echo "Waiting for Hub API... attempt $i"
           sleep 5
         done
-        echo "Hub API never became ready"
-        exit 1
+        if [ "$ready" != "true" ]; then
+          echo "Hub API never became ready"
+          exit 1
+        fi
+        # Verify auth is actually enforced: unauthenticated requests must 401
+        code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/applications)
+        if [ "$code" != "401" ]; then
+          echo "Expected 401 without credentials, got $code - auth is not enforced"
+          exit 1
+        fi
+        echo "Auth is enforced"
 
     - name: Build Koncur
       shell: bash
@@ -170,29 +163,17 @@ runs:
         path: "${{ runner.temp }}/settings.xml"
 
     - name: Create Hub target config
-      if: ${{ !inputs.skip_maven }}
       shell: bash
       run: |
         mkdir -p .koncur/config
         printf 'type: tackle-hub\n' > .koncur/config/target-tackle-hub.yaml
         printf 'tackleHub:\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  url: https://tackle.local:8443/hub\n' >> .koncur/config/target-tackle-hub.yaml
+        printf '  url: http://localhost:8081\n' >> .koncur/config/target-tackle-hub.yaml
         printf '  username: admin\n' >> .koncur/config/target-tackle-hub.yaml
         printf '  password: admin\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  insecure: true\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  mavenSettings: "%s"\n' "${{ runner.temp }}/settings.xml" >> .koncur/config/target-tackle-hub.yaml
-
-    - name: Create Hub target config (no maven)
-      if: ${{ inputs.skip_maven }}
-      shell: bash
-      run: |
-        mkdir -p .koncur/config
-        printf 'type: tackle-hub\n' > .koncur/config/target-tackle-hub.yaml
-        printf 'tackleHub:\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  url: https://tackle.local:8443/hub\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  username: admin\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  password: admin\n' >> .koncur/config/target-tackle-hub.yaml
-        printf '  insecure: true\n' >> .koncur/config/target-tackle-hub.yaml
+        if [ "${{ inputs.skip_maven }}" != "true" ]; then
+          printf '  mavenSettings: "%s"\n' "${{ runner.temp }}/settings.xml" >> .koncur/config/target-tackle-hub.yaml
+        fi
 
     - name: Run test
       shell: bash

--- a/setup-konveyor-minikube/action.yml
+++ b/setup-konveyor-minikube/action.yml
@@ -30,12 +30,16 @@ inputs:
     description: Image URI for tackle-postgres
     required: false
     default: ""
+  # BACKCOMPAT: The operator no longer deploys Keycloak on main (auth moved to the
+  # hub's built-in OIDC provider in tackle2-operator#567), so these inputs are
+  # ignored there. Kept so operator bundles from pre-hub-IdP branches (base_tag =
+  # release-0.9 and earlier) can still be built; delete once those are retired.
   keycloak_sso:
-    description: Image URI for keycloak_sso
+    description: "DEPRECATED - ignored on operator main; only used when base_tag points at a pre-hub-IdP operator branch (e.g. release-0.9)"
     required: false
     default: ""
   keycloak_init:
-    description: Image URI for keycloak_init
+    description: "DEPRECATED - ignored on operator main; only used when base_tag points at a pre-hub-IdP operator branch (e.g. release-0.9)"
     required: false
     default: ""
   tackle_ui:
@@ -121,6 +125,8 @@ runs:
         oauth_proxy: ${{ inputs.oauth_proxy }}
         tackle_hub: ${{ inputs.tackle_hub }}
         tackle_postgres: ${{ inputs.tackle_postgres }}
+        # BACKCOMPAT: only used when base_tag points at a pre-hub-IdP operator
+        # branch (e.g. release-0.9); operator@main's make-bundle ignores these.
         keycloak_sso: ${{ inputs.keycloak_sso }}
         keycloak_init: ${{ inputs.keycloak_init }}
         tackle_ui: ${{ inputs.tackle_ui }}


### PR DESCRIPTION
## Summary

The operator no longer deploys Keycloak (konveyor/tackle2-operator#567) — auth moved to the hub's built-in OIDC provider, which seeds a default `admin`/`admin` user. The `koncur-tackle-hub` action was waiting on and patching a `tackle-keycloak-sso` deployment that no longer exists, timing out every run.

Companion PR (merge first): konveyor/koncur#95

Koncur PR: 95

## Changes

- **koncur-tackle-hub**: drop the tackle.local/Keycloak reconfiguration and keycloak pod wait; reach the hub via `make hub-forward` (port-forward to `http://localhost:8081`) with Basic auth `admin`/`admin`, and assert unauthenticated requests get a 401 so the auth path is genuinely exercised. Merge the two duplicated target-config steps.
- **nightly-koncur / e2e-hub-koncur**: remove the dead `tackle-keycloak-init` artifact from `image_pattern` globs (main's nightly matrix builds no keycloak image).
- **global-ci-bundle / setup-konveyor-minikube**: keep the `keycloak_sso`/`keycloak_init` inputs for backward compatibility with pre-hub-IdP operator branches (release-0.9), marked DEPRECATED with BACKCOMPAT comments explaining why they exist and when they can be deleted. Removing a `workflow_call` input hard-errors any caller that passes it.

## Notes

- release-0.9 flows are unaffected: `nightly-koncur-0.9.yaml` never invokes `koncur-tackle-hub`, and the 0.9 workflows run from `@release-0.9` refs of this repo.
- No caller of `global-ci-bundle.yml@main` currently passes the keycloak inputs (audited tackle2-hub, tackle2-ui, rulesets, tackle2-seed, go-konveyor-tests, operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)