### PR TITLE
Pin podman-cli to v5.8.1 on Windows to fix nightly failures

### DIFF
--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -600,7 +600,8 @@ jobs:
         shell: bash
         run: |
           for i in {1..3}; do
-            choco install podman-cli && break
+            # Pinned to 5.8.1 to work around SSH connection failures with Podman 6.0 on Windows
+            choco install podman-cli --version=5.8.1 && break
             echo "Chocolatey install failed (attempt $i/3), retrying in 30s..."
             sleep 30
           done

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -37,7 +37,8 @@ runs:
       shell: bash
       run: |
         for i in {1..3}; do
-          choco install podman-cli && break
+          # Pinned to 5.8.1 to work around SSH connection failures with Podman 6.0 on Windows
+          choco install podman-cli --version=5.8.1 && break
           echo "Chocolatey install failed (attempt $i/3), retrying in 30s..."
           sleep 30
         done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Windows Podman setup to use a pinned `podman-cli` version, helping ensure more consistent and reliable environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->