### PR TITLE
Include base image deps when filtering PR matrix by repo

### DIFF
--- a/scripts/parse_matrix_config.py
+++ b/scripts/parse_matrix_config.py
@@ -291,9 +291,12 @@ def organize_by_levels(
                 ):
                     has_matching_descendant = True
 
-        # Include this job if it matches or we're already including (parent matched)
-        # Don't include just because of matching descendants
-        if matches or include:
+        # Include this job if it matches, we're already including (parent matched),
+        # or a filtered descendant needs this job's image built first (PR builds).
+        needs_build_for_descendant = (
+            repo_filter is not None and has_matching_descendant and not matches
+        )
+        if matches or include or needs_build_for_descendant:
             job_copy = {k: v for k, v in job.items() if k != "dependent_jobs"}
 
             # Add base_image field for dependent jobs


### PR DESCRIPTION
## Summary

- When `parse_matrix_config.py` filters the image matrix to a single repo (e.g. `konveyor/analyzer-lsp` on PR builds), include ancestor jobs whose images are referenced as `base_image` by filtered dependents
- Fixes analyzer-lsp PR CI where `java-external-provider` sets `base_image` to `jdtls-server-base` but `jdtls-server-base` was never built in the same workflow run

## Problem

On `feature/262-refactor-generic-provider`, dependent jobs always receive a `base_image` pointing at their parent image. For analyzer-lsp PRs, `java-external-provider` expects an artifact named `quay.io_konveyor_jdtls-server-base--<run_id>`, but `konveyor/java-analyzer-bundle` was excluded by the repo filter.

## Test plan

- [ ] Re-run analyzer-lsp PR #1169 (or any nodejs-only PR) and confirm level 0 builds `jdtls-server-base` and level 1 `java-external-provider` succeeds
- [ ] Confirm nightly full-matrix builds are unchanged when no `-r` repo filter is used


Made with [Cursor](https://cursor.com)