### PR TITLE
Add release-0.10 nightly

### DIFF
--- a/.github/workflows/ci-repo.yaml
+++ b/.github/workflows/ci-repo.yaml
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/global-ci.yml
     with:
       component_name: test-images
-      run_api_tests: true
+      run_api_tests: false
       run_ui_tests: true
 
   global-ci-bundle:
@@ -53,7 +53,7 @@ jobs:
     uses: ./.github/workflows/global-ci-bundle.yml
     with:
       artifact: test-images
-      run_api_tests: true
+      run_api_tests: false
       run_ui_tests: true
       run_koncur_hub_tests: true
       run_koncur_kantra_tests: true

--- a/.github/workflows/nightly-koncur-0.10.yaml
+++ b/.github/workflows/nightly-koncur-0.10.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   nightly:
+    if: github.repository == 'konveyor/ci'
     uses: konveyor/ci/.github/workflows/nightly-koncur.yaml@main
     with:
       branch: release-0.10

--- a/.github/workflows/nightly-koncur-0.10.yaml
+++ b/.github/workflows/nightly-koncur-0.10.yaml
@@ -1,0 +1,13 @@
+name: Run Koncur nightly (Release 0.10)
+
+on:
+  schedule:
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    uses: konveyor/ci/.github/workflows/nightly-koncur.yaml@main
+    with:
+      branch: release-0.10
+    secrets: inherit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated nightly validation for the 0.10 release branch.
  * Added the ability to trigger the nightly workflow manually.
  * Updated CI to skip API test execution for the `test-images` artifact, while keeping UI tests enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->