### PR TITLE
:bug: Use correct images for release workflows

### DIFF
--- a/koncur-kantra/check_images.sh
+++ b/koncur-kantra/check_images.sh
@@ -75,9 +75,16 @@ if [ ${#MISSING[@]} -gt 0 ]; then
         VERSION="${CLEAN_TAG#release-}"
         if [ "$VERSION" != "$CLEAN_TAG" ]; then
             CANDIDATE="nightly-koncur-${VERSION}.yaml"
-            if gh run list -R=konveyor/ci --workflow="$CANDIDATE" --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null | grep -q .; then
-                NIGHTLY_WORKFLOW="$CANDIDATE"
-                echo "Using versioned nightly workflow: $NIGHTLY_WORKFLOW"
+            PROBE_OUTPUT=""
+            if PROBE_OUTPUT=$(gh run list -R=konveyor/ci --workflow="$CANDIDATE" --branch=main --limit=1 --json databaseId --jq '.[0].databaseId' 2>&1); then
+                if [ -n "$PROBE_OUTPUT" ] && [ "$PROBE_OUTPUT" != "null" ]; then
+                    NIGHTLY_WORKFLOW="$CANDIDATE"
+                    echo "Using versioned nightly workflow: $NIGHTLY_WORKFLOW"
+                else
+                    echo "Versioned workflow $CANDIDATE exists but has no runs on main, using default"
+                fi
+            else
+                echo "Could not query workflow $CANDIDATE (gh error: $PROBE_OUTPUT), using default"
             fi
         fi
     fi

--- a/koncur-kantra/check_images.sh
+++ b/koncur-kantra/check_images.sh
@@ -66,9 +66,25 @@ if [ ${#MISSING[@]} -gt 0 ]; then
 
     echo "Attempting to download missing images from a recent nightly run..."
 
+    # Determine the correct nightly workflow based on FALLBACK_TAG.
+    # Release branches use version-specific workflows (e.g. nightly-koncur-0.9.yaml).
+    NIGHTLY_WORKFLOW="nightly-koncur.yaml"
+    if [ -n "$FALLBACK_TAG" ] && [ "$FALLBACK_TAG" != "main" ] && [ "$FALLBACK_TAG" != "latest" ]; then
+        CLEAN_TAG="${FALLBACK_TAG#refs/heads/}"
+        CLEAN_TAG="${CLEAN_TAG#refs/tags/}"
+        VERSION="${CLEAN_TAG#release-}"
+        if [ "$VERSION" != "$CLEAN_TAG" ]; then
+            CANDIDATE="nightly-koncur-${VERSION}.yaml"
+            if gh run list -R=konveyor/ci --workflow="$CANDIDATE" --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null | grep -q .; then
+                NIGHTLY_WORKFLOW="$CANDIDATE"
+                echo "Using versioned nightly workflow: $NIGHTLY_WORKFLOW"
+            fi
+        fi
+    fi
+
     # Find recent nightly runs (any status — image builds often succeed even when
     # unrelated test jobs fail, and --status=success would skip those runs entirely)
-    WORKFLOW_RUNS=$(gh run list -R=konveyor/ci --workflow=nightly-koncur.yaml --branch=main --limit=10 --json databaseId --jq '.[].databaseId')
+    WORKFLOW_RUNS=$(gh run list -R=konveyor/ci --workflow="$NIGHTLY_WORKFLOW" --branch=main --limit=10 --json databaseId --jq '.[].databaseId')
 
     if [ -z "$WORKFLOW_RUNS" ]; then
         echo "Error: Could not find any nightly workflow runs"


### PR DESCRIPTION
The `release-0.9` nightly produces `quay.io_konveyor_kantra--release-0.9_2026.07.23` artifacts. With the fix, check_images.sh will now search nightly-koncur-0.9.yaml instead of nightly-koncur.yaml, find these artifacts, and load `release-0.9` images instead of `release-0.10`.

**Before**: Always searched nightly-koncur.yaml (the default/main nightly), which produces release-0.10 images.

**After**: When FALLBACK_TAG=release-0.9, it:
1. Strips ref prefixes and extracts the version (0.9)
2. Checks if nightly-koncur-0.9.yaml exists (by verifying it has runs)
3. If it does, uses that workflow instead — which produces release-0.9 tagged artifacts like quay.io_konveyor_kantra--release-0.9_2026.07.23
4. Falls back to the default workflow if no versioned one exists

The release-0.9 nightly image builds are all succeeding (kantra, c-sharp-provider, java-external-provider, etc.), so the artifacts will be found and loaded correctly. The changes are ready — you can stage, commit, and push when ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image artifact downloads for release branches and tags by automatically selecting the matching nightly workflow when available.
  * Increased reliability when locating nightly workflow runs for non-main releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->