### PR TITLE
:bug: Fix crun issue

### DIFF
--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -192,8 +192,9 @@ runs:
           aarch64) ARCH="arm64" ;;
         esac
         echo "Upgrading crun to ${CRUN_VERSION} for OCI runtime spec v1.2.1 compatibility"
-        curl -sLo /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}"
+        curl -sfLo /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}"
         chmod +x /tmp/crun
+        /tmp/crun --version | head -1 | grep -q "crun version ${CRUN_VERSION}" || { echo "Downloaded crun reports unexpected version"; /tmp/crun --version; exit 1; }
         sudo mv /tmp/crun /usr/bin/crun
         echo "crun version: $(crun --version | head -1)"
 

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -178,6 +178,25 @@ runs:
         echo "Loaded images:" | tee -a "$GITHUB_STEP_SUMMARY"
         podman images | tee -a "$GITHUB_STEP_SUMMARY"
 
+    # GitHub runner image 20260726.74 ships a podman that generates OCI
+    # runtime spec v1.2.1, but its bundled crun is too old to parse it,
+    # causing "unknown version specified" on every RUN step in a build.
+    # See: https://github.com/containers/crun/issues/1485
+    - name: Upgrade crun for OCI spec compatibility
+      shell: bash
+      run: |
+        CRUN_VERSION="1.28"
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64)  ARCH="amd64" ;;
+          aarch64) ARCH="arm64" ;;
+        esac
+        echo "Upgrading crun to ${CRUN_VERSION} for OCI runtime spec v1.2.1 compatibility"
+        curl -sLo /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}"
+        chmod +x /tmp/crun
+        sudo mv /tmp/crun /usr/bin/crun
+        echo "crun version: $(crun --version | head -1)"
+
     - name: Build image with podman
       id: build_image
       shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image build reliability by hardening the OCI runtime upgrade step used during builds.
  * Added stricter validation of the downloaded runtime binary to detect unexpected versions early, reducing the likelihood of build failures due to runtime/spec incompatibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->