### PR TITLE
:bug: Pass ARG for base image

### DIFF
--- a/.github/workflows/nightly-matrix-config-0.9.yaml
+++ b/.github/workflows/nightly-matrix-config-0.9.yaml
@@ -28,6 +28,7 @@ config:
         image: "quay.io/konveyor/tackle2-addon-analyzer"
         dockerfile_path: "Dockerfile"
         context_path: "."
+        base_image_arg: ANALYZER_LSP_IMAGE
         go_mod_update:
           - "github.com/konveyor/analyzer-lsp@BRANCH_PLACEHOLDER"
 


### PR DESCRIPTION
`release-0.9` nighly is failing due to overnight changes in the ubi images. The tackle2-addon-analyzer project was also basing its image always on the analyzer-lsp's `latest` tag.

See https://github.com/konveyor/tackle2-addon-analyzer/pull/204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly analyzer configuration to use the specified analyzer image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->