### PR TITLE
Run Koncur hub tests in release-0.9 nightly

### DIFF
--- a/.github/workflows/nightly-koncur-0.9.yaml
+++ b/.github/workflows/nightly-koncur-0.9.yaml
@@ -172,6 +172,8 @@ jobs:
 
   run-koncur-tackle-hub-action:
     if: ${{ !cancelled() && !failure() }}
+    permissions:
+      contents: read
     needs:
     - build-images
     - build-level1-images

--- a/.github/workflows/nightly-koncur-0.9.yaml
+++ b/.github/workflows/nightly-koncur-0.9.yaml
@@ -135,12 +135,6 @@ jobs:
 ## Now we need to test full e2e kantra, kai, and the ui/operator.
 ## The e2e tests for these, should be in the repos, because an end user
 ## may need to debug them. 
-# # For now, to get this workflow working, and show it, I will create the matrix
-#
-## To start, I am going to add back something that looks like the API tests
-## And something that looks like the UI tests.  
-#
-# This will just do kantra testing on the images now.
 #
 #
   run-koncur-kantra-action:
@@ -176,8 +170,27 @@ jobs:
             *{kantra,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'release-0.9' }}
 
+  run-koncur-tackle-hub-action:
+    if: ${{ !cancelled() && !failure() }}
+    needs:
+    - build-images
+    - build-level1-images
+    - build-level2-images
+    - build-level3-images
+    - nightly-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Koncur hub tests
+        id: koncur-tackle-hub-test
+        uses: konveyor/ci/koncur-tackle-hub@main
+        with:
+          image_pattern: |
+            *{tackle-keycloak-init,tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
+          ref: ${{ inputs.branch || 'release-0.9' }}
+
   report_failure:
     needs:
+    - run-koncur-tackle-hub-action
     - run-koncur-kantra-action
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves #215 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Tackle Hub tests to the nightly validation workflow.
  * Tackle Hub tests now run after image builds and nightly tagging are complete.
  * Failure reporting now includes results from Tackle Hub tests.
* **Chores**
  * Removed obsolete workflow documentation.
  * Improved nightly validation coverage and failure visibility across automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->