### PR TITLE
Run koncur tests that require maven settings in nightlies

### DIFF
--- a/.github/workflows/e2e-hub-koncur.yaml
+++ b/.github/workflows/e2e-hub-koncur.yaml
@@ -59,4 +59,5 @@ jobs:
         with:
           image_pattern: |
             *{tackle2-*,provider}--${{ github.run_id }}
-          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
+          ref: ${{ github.base_ref || inputs.ref || github.ref_name }}
+          koncur_ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -181,7 +181,7 @@ on:
         description: Whether to skip setting up maven for koncur tests
         type: boolean
         required: false
-        default: true
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -607,3 +607,4 @@ jobs:
         with:
           os: ${{ matrix.os }}
           ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
+          skip_maven: ${{ inputs.koncur_skip_maven }}

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -521,74 +521,19 @@ jobs:
           fi
 
   koncur-hub-tests:
-    needs: [check-images, extract-koncur-ref]
+    needs: [extract-koncur-ref]
     runs-on: ubuntu-latest
     if: ${{ inputs.run_koncur_hub_tests }}
     steps:
-      - name: Setup Konveyor
-        uses: konveyor/ci/setup-konveyor-minikube@main
-        with:
-          artifact: ${{ inputs.artifact }}
-          operator_bundle: ${{ inputs.operator_bundle }}
-          operator_bundle_fallback: ${{ env.operator_bundle }}
-          base_tag: ${{ inputs.base_tag }}
-          oauth_proxy: ${{ inputs.oauth_proxy }}
-          tackle_hub: ${{ inputs.tackle_hub }}
-          tackle_postgres: ${{ inputs.tackle_postgres }}
-          # BACKCOMPAT: only used when a pre-hub-IdP operator (e.g. release-0.9) is targeted
-          keycloak_sso: ${{ inputs.keycloak_sso }}
-          keycloak_init: ${{ inputs.keycloak_init }}
-          tackle_ui: ${{ inputs.tackle_ui }}
-          addon_analyzer: ${{ inputs.addon_analyzer }}
-          addon_discovery: ${{ inputs.addon_discovery }}
-          namespace: ${{ inputs.namespace }}
-          tackle_cr: ${{ inputs.tackle_cr }}
-
-      - name: Checkout koncur
+      - name: Checkout CI repo
         uses: actions/checkout@v4
-        with:
-          repository: konveyor/koncur
-          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
-          path: koncur
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-
-      - name: Build Koncur
-        run: |
-          cd koncur
-          go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Start port-forward
-        run: |
-          kubectl port-forward -n konveyor-tackle svc/tackle-hub 8081:8080 &
-          sleep 5
-
-      - name: Create Hub target config
-        run: |
-          mkdir -p .koncur/config
-          cat > .koncur/config/target-tackle-hub.yaml << 'EOF'
-          type: tackle-hub
-          tackleHub:
-            url: http://localhost:8081
-          EOF
 
       - name: Run Koncur Hub tests
-        working-directory: koncur
-        env:
-          SKIP_MAVEN: ${{ inputs.koncur_skip_maven }}
-        run: koncur run tests -t tackle-hub --target-config ../.koncur/config/target-tackle-hub.yaml -o yaml --output-file test-hub.yaml
-
-      - name: Upload result yaml
-        uses: actions/upload-artifact@v4
-        if: always()
+        uses: ./koncur-tackle-hub
         with:
-          name: koncur-hub-summary
-          path: koncur/test-hub.yaml
-          retention-days: 3
+          ref: ${{ inputs.base_tag }}
+          koncur_ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
+          skip_maven: ${{ inputs.koncur_skip_maven }}
 
   koncur-kantra-tests:
     needs: [check-images, extract-koncur-ref, setup-kantra-matrix]

--- a/.github/workflows/global-ci-bundle.yml
+++ b/.github/workflows/global-ci-bundle.yml
@@ -279,6 +279,8 @@ env:
 jobs:
   check-images:
     runs-on: ubuntu-22.04
+    outputs:
+      kantra_image: ${{ steps.kantra-image.outputs.image }}
     steps:
       - name: Check operator image exists
         if: ${{ inputs.operator_bundle != '' }}
@@ -325,6 +327,7 @@ jobs:
         if: ${{ inputs.addon_discovery != '' }}
         run: docker manifest inspect ${{ inputs.addon_discovery }}
       - name: Check kantra image exists
+        id: kantra-image
         if: ${{ inputs.run_koncur_kantra_tests }}
         run: |
           KANTRA_IMAGE="$KANTRA_INPUT"
@@ -332,6 +335,7 @@ jobs:
             KANTRA_IMAGE="quay.io/konveyor/kantra:${BASE_TAG_INPUT}"
           fi
           docker manifest inspect "$KANTRA_IMAGE"
+          echo "image=$KANTRA_IMAGE" >> $GITHUB_OUTPUT
 
   e2e-api-integration-tests:
     needs: check-images
@@ -593,80 +597,13 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-kantra-matrix.outputs.matrix) }}
     steps:
-      - name: Download and install kantra (linux)
-        if: ${{ matrix.os == 'linux' }}
-        run: |
-          KANTRA_IMAGE="$KANTRA_INPUT"
-          if [ -z "$KANTRA_IMAGE" ]; then
-            KANTRA_IMAGE="quay.io/konveyor/kantra:${BASE_TAG_INPUT}"
-          fi
-          mkdir -p $HOME/.local/bin
-          podman cp "$(podman create --name kantra-download "$KANTRA_IMAGE")":/usr/local/bin/kantra $HOME/.local/bin/kantra
-          podman rm kantra-download
-          chmod +x $HOME/.local/bin/kantra
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install podman (windows)
-        if: ${{ matrix.os == 'windows' }}
-        shell: bash
-        run: |
-          for i in {1..3}; do
-            # Pinned to 5.8.1 to work around SSH connection failures with Podman 6.0 on Windows
-            choco install podman-cli --version=5.8.1 && break
-            echo "Chocolatey install failed (attempt $i/3), retrying in 30s..."
-            sleep 30
-          done
-          podman machine init --rootful --memory 10240 --cpus 3
-          podman machine start
-
-      - name: Download and install kantra (windows)
-        if: ${{ matrix.os == 'windows' }}
-        shell: bash
-        run: |
-          KANTRA_IMAGE="$KANTRA_INPUT"
-          if [ -z "$KANTRA_IMAGE" ]; then
-            KANTRA_IMAGE="quay.io/konveyor/kantra:${BASE_TAG_INPUT}"
-          fi
-          mkdir -p $HOME/.local/bin
-          podman cp "$(podman create --name kantra-download "$KANTRA_IMAGE")":/usr/local/bin/windows-kantra $HOME/.local/bin/kantra.exe
-          podman rm kantra-download
-
-      - name: Add local bin to path (windows)
-        if: ${{ matrix.os == 'windows' }}
-        shell: powershell
-        run: |
-          $newPath = "$env:USERPROFILE\.local\bin"
-          Write-Output "$newPath" >> $env:GITHUB_PATH
-
-      - name: Checkout koncur
+      - name: Checkout CI repo
         uses: actions/checkout@v4
-        with:
-          repository: konveyor/koncur
-          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}
-          path: koncur
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-
-      - name: Build Koncur
-        shell: bash
-        run: |
-          cd koncur
-          go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
       - name: Run Koncur Kantra tests
-        shell: bash
-        working-directory: koncur
+        uses: ./koncur-kantra
         env:
-          SKIP_MAVEN: ${{ inputs.koncur_skip_maven }}
-        run: koncur run tests -t kantra -o yaml --output-file test-kantra.yaml
-
-      - name: Upload result yaml
-        uses: actions/upload-artifact@v4
-        if: always()
+          RUNNER_IMG: ${{ needs.check-images.outputs.kantra_image }}
         with:
-          name: koncur-kantra-${{ matrix.os }}-summary
-          path: koncur/test-kantra.yaml
-          retention-days: 3
+          os: ${{ matrix.os }}
+          ref: ${{ needs.extract-koncur-ref.outputs.koncur_ref }}

--- a/.github/workflows/nightly-koncur-0.9.yaml
+++ b/.github/workflows/nightly-koncur-0.9.yaml
@@ -189,6 +189,7 @@ jobs:
           image_pattern: |
             *{tackle-keycloak-init,tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'release-0.9' }}
+          koncur_ref: ${{ inputs.branch || 'release-0.9' }}
 
   report_failure:
     needs:

--- a/.github/workflows/nightly-koncur.yaml
+++ b/.github/workflows/nightly-koncur.yaml
@@ -175,6 +175,7 @@ jobs:
           image_pattern: |
             *{kantra,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'main' }}
+          skip_maven: false
   
   run-koncur-tackle-hub-action:
     if: ${{ !cancelled() && !failure() }}
@@ -193,6 +194,7 @@ jobs:
           image_pattern: |
             *{tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'main' }}
+          skip_maven: false
 
   report_failure:
     needs:

--- a/.github/workflows/nightly-koncur.yaml
+++ b/.github/workflows/nightly-koncur.yaml
@@ -194,6 +194,7 @@ jobs:
           image_pattern: |
             *{tackle2-*,provider}--${{ needs.nightly-tag.outputs.tag }}
           ref: ${{ inputs.branch || 'main' }}
+          koncur_ref: ${{ inputs.branch || 'main' }}
           skip_maven: false
 
   report_failure:

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -3,7 +3,7 @@ name: Koncur Kantra
 inputs:
   skip_maven:
     description: "Whether to setup access to the testing maven packages"
-    default: true
+    default: false
     type: boolean
   os:
     description: OS that the action is running on, one of macos, windows, linux
@@ -149,7 +149,7 @@ runs:
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
     - name: Allow firewall rule
-      if: ${{ !inputs.skip_maven && inputs.os == 'windows-latest' }}
+      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows-latest' }}
       shell: powershell
       run: |
         $wslAdapter = Get-NetAdapter | Where-Object {$_.Name -like "*WSL*"}
@@ -163,14 +163,14 @@ runs:
         }
 
     - name: Run server for maven-local-resources
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       uses: Eun/http-server-action@v1
       with:
         directory: local-maven-resources
         port: 8085
 
     - name: Set maven settings path (Windows)
-      if: ${{ !inputs.skip_maven && inputs.os == 'windows' }}
+      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows' }}
       shell: bash
       run: |
         # Create directory using bash
@@ -180,14 +180,14 @@ runs:
         echo "MAVEN_SETTINGS_PATH=$WINDOWS_PATH" >> $GITHUB_ENV
 
     - name: Set maven settings path (*nix)
-      if: ${{ !inputs.skip_maven && inputs.os != 'windows-latest' }}
+      if: ${{ inputs.skip_maven == 'false' && inputs.os != 'windows-latest' }}
       shell: bash
       run: |
         mkdir -p "$HOME/.koncur/temp"
         echo "MAVEN_SETTINGS_PATH=$HOME/.koncur/temp/settings.xml" >> $GITHUB_ENV
 
     - name: Create maven settings file
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       uses: s4u/maven-settings-action@v4.0.0
       with:
         githubServer: false
@@ -196,7 +196,7 @@ runs:
         path: "${{ env.MAVEN_SETTINGS_PATH }}"
 
     - name: Create kantra config
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       shell: bash
       run: |
         mkdir -p .koncur/config

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -137,6 +137,7 @@ runs:
       with:
         repository: konveyor/koncur
         ref: ${{ inputs.ref }}
+        path: koncur
 
     - name: Setup go
       uses: actions/setup-go@v6
@@ -145,6 +146,7 @@ runs:
 
     - name: Build Koncur
       shell: bash
+      working-directory: koncur
       run: |
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
@@ -166,7 +168,7 @@ runs:
       if: ${{ inputs.skip_maven == 'false' }}
       uses: Eun/http-server-action@v1
       with:
-        directory: local-maven-resources
+        directory: koncur/local-maven-resources
         port: 8085
 
     - name: Set maven settings path (Windows)
@@ -198,6 +200,7 @@ runs:
     - name: Create kantra config
       if: ${{ inputs.skip_maven == 'false' }}
       shell: bash
+      working-directory: koncur
       run: |
         mkdir -p .koncur/config
         cat << 'EOF' > .koncur/config/target-kantra.yaml
@@ -208,6 +211,7 @@ runs:
 
     - name: Run test
       shell: bash
+      working-directory: koncur
       env:
         SKIP_MAVEN: ${{ fromJSON(inputs.skip_maven) }}
       run: |
@@ -219,7 +223,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: koncur-kantra-${{ inputs.os }}-failures
-        path: .koncur/output 
+        path: koncur/.koncur/output
         retention-days: 5
         include-hidden-files: true
 
@@ -228,5 +232,5 @@ runs:
       if: always()
       with:
         name: koncur-kantra-${{ inputs.os }}-summary
-        path: test.yaml
+        path: koncur/test.yaml
         retention-days: 3

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -149,7 +149,7 @@ runs:
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
     - name: Allow firewall rule
-      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows-latest' }}
+      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows' }}
       shell: powershell
       run: |
         $wslAdapter = Get-NetAdapter | Where-Object {$_.Name -like "*WSL*"}
@@ -180,7 +180,7 @@ runs:
         echo "MAVEN_SETTINGS_PATH=$WINDOWS_PATH" >> $GITHUB_ENV
 
     - name: Set maven settings path (*nix)
-      if: ${{ inputs.skip_maven == 'false' && inputs.os != 'windows-latest' }}
+      if: ${{ inputs.skip_maven == 'false' && inputs.os != 'windows' }}
       shell: bash
       run: |
         mkdir -p "$HOME/.koncur/temp"

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -151,7 +151,7 @@ runs:
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
 
     - name: Allow firewall rule
-      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows' }}
+      if: ${{ !fromJSON(inputs.skip_maven) && inputs.os == 'windows' }}
       shell: powershell
       run: |
         $wslAdapter = Get-NetAdapter | Where-Object {$_.Name -like "*WSL*"}
@@ -165,14 +165,14 @@ runs:
         }
 
     - name: Run server for maven-local-resources
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       uses: Eun/http-server-action@v1
       with:
         directory: koncur/local-maven-resources
         port: 8085
 
     - name: Set maven settings path (Windows)
-      if: ${{ inputs.skip_maven == 'false' && inputs.os == 'windows' }}
+      if: ${{ !fromJSON(inputs.skip_maven) && inputs.os == 'windows' }}
       shell: bash
       run: |
         # Create directory using bash
@@ -182,14 +182,14 @@ runs:
         echo "MAVEN_SETTINGS_PATH=$WINDOWS_PATH" >> $GITHUB_ENV
 
     - name: Set maven settings path (*nix)
-      if: ${{ inputs.skip_maven == 'false' && inputs.os != 'windows' }}
+      if: ${{ !fromJSON(inputs.skip_maven) && inputs.os != 'windows' }}
       shell: bash
       run: |
         mkdir -p "$HOME/.koncur/temp"
         echo "MAVEN_SETTINGS_PATH=$HOME/.koncur/temp/settings.xml" >> $GITHUB_ENV
 
     - name: Create maven settings file
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       uses: s4u/maven-settings-action@v4.0.0
       with:
         githubServer: false
@@ -198,7 +198,7 @@ runs:
         path: "${{ env.MAVEN_SETTINGS_PATH }}"
 
     - name: Create kantra config
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       shell: bash
       working-directory: koncur
       run: |

--- a/koncur-kantra/action.yml
+++ b/koncur-kantra/action.yml
@@ -3,7 +3,7 @@ name: Koncur Kantra
 inputs:
   skip_maven:
     description: "Whether to setup access to the testing maven packages"
-    default: false
+    default: true
     type: boolean
   os:
     description: OS that the action is running on, one of macos, windows, linux

--- a/koncur-tackle-hub/action.yml
+++ b/koncur-tackle-hub/action.yml
@@ -3,7 +3,7 @@ name: Koncur Tackle Hub
 inputs:
   skip_maven:
     description: "Whether to setup access to the testing maven packages"
-    default: false
+    default: true
     type: boolean
   image_pattern:
     description: The pattern used to download the image's that have been built to test

--- a/koncur-tackle-hub/action.yml
+++ b/koncur-tackle-hub/action.yml
@@ -3,7 +3,7 @@ name: Koncur Tackle Hub
 inputs:
   skip_maven:
     description: "Whether to setup access to the testing maven packages"
-    default: true
+    default: false
     type: boolean
   image_pattern:
     description: The pattern used to download the image's that have been built to test
@@ -182,14 +182,14 @@ runs:
         echo $HOME/.local/bin >> $GITHUB_PATH
     # Maven setup - mirrors kantra.yaml approach using local HTTP server
     - name: Run server for maven-local-resources
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       uses: Eun/http-server-action@v1
       with:
         directory: local-maven-resources
         port: 8085
 
     - name: Get Kind network gateway
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       shell: bash
       run: |
         # Get the gateway IP from inside the Kind container's routing table
@@ -199,7 +199,7 @@ runs:
         echo "Kind gateway: $GATEWAY"
 
     - name: Create maven settings file
-      if: ${{ !inputs.skip_maven }}
+      if: ${{ inputs.skip_maven == 'false' }}
       uses: s4u/maven-settings-action@v4.0.0
       with:
         githubServer: false

--- a/koncur-tackle-hub/action.yml
+++ b/koncur-tackle-hub/action.yml
@@ -192,14 +192,14 @@ runs:
         echo $HOME/.local/bin >> $GITHUB_PATH
 
     - name: Run server for maven-local-resources
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       uses: Eun/http-server-action@v1
       with:
         directory: koncur/local-maven-resources
         port: 8085
 
     - name: Get Kind network gateway
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       shell: bash
       run: |
         # Get the gateway IP from inside the Kind container's routing table
@@ -209,7 +209,7 @@ runs:
         echo "Kind gateway: $GATEWAY"
 
     - name: Create maven settings file
-      if: ${{ inputs.skip_maven == 'false' }}
+      if: ${{ !fromJSON(inputs.skip_maven) }}
       uses: s4u/maven-settings-action@v4.0.0
       with:
         githubServer: false

--- a/koncur-tackle-hub/action.yml
+++ b/koncur-tackle-hub/action.yml
@@ -10,6 +10,11 @@ inputs:
     required: false
     type: string
   ref:
+    description: The ref used for pulling images (fallback tag)
+    required: false
+    type: string
+    default: main
+  koncur_ref:
     description: The ref of koncur to use for testing
     required: false
     type: string
@@ -21,8 +26,9 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v6
       with:
-        ref: ${{ inputs.ref }}
+        ref: ${{ inputs.koncur_ref }}
         repository: konveyor/koncur
+        path: koncur
 
     - name: Setup Go
       uses: actions/setup-go@v6
@@ -47,6 +53,7 @@ runs:
 
     - name: Create Kind cluster
       shell: bash
+      working-directory: koncur
       run: make kind-create
 
 
@@ -80,6 +87,7 @@ runs:
 
     - name: Install Tackle Hub with auth
       shell: bash
+      working-directory: koncur
       env:
         RUNNER_IMG: ${{ env.RUNNER_IMG }}
         JAVA_PROVIDER_IMG: ${{ env.JAVA_PROVIDER_IMG }}
@@ -103,6 +111,7 @@ runs:
 
     - name: Start port-forward
       shell: bash
+      working-directory: koncur
       run: make hub-forward &
 
     - name: Wait for Hub API (auth)
@@ -177,15 +186,16 @@ runs:
 
     - name: Build Koncur
       shell: bash
+      working-directory: koncur
       run: |
         go build -o $HOME/.local/bin/koncur ./cmd/koncur/main.go
         echo $HOME/.local/bin >> $GITHUB_PATH
-    # Maven setup - mirrors kantra.yaml approach using local HTTP server
+
     - name: Run server for maven-local-resources
       if: ${{ inputs.skip_maven == 'false' }}
       uses: Eun/http-server-action@v1
       with:
-        directory: local-maven-resources
+        directory: koncur/local-maven-resources
         port: 8085
 
     - name: Get Kind network gateway
@@ -209,6 +219,7 @@ runs:
 
     - name: Create Hub target config
       shell: bash
+      working-directory: koncur
       run: |
         mkdir -p .koncur/config
         printf 'type: tackle-hub\n' > .koncur/config/target-tackle-hub.yaml
@@ -222,6 +233,7 @@ runs:
 
     - name: Run test
       shell: bash
+      working-directory: koncur
       env:
         SKIP_MAVEN: ${{ inputs.skip_maven }}
       run: |
@@ -256,7 +268,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: koncur-hub-failures
-        path: .koncur
+        path: koncur/.koncur
         retention-days: 5
 
     - name: Upload result yaml
@@ -264,7 +276,7 @@ runs:
       if: always()
       with:
         name: koncur-hub-summary
-        path: test-hub.yaml
+        path: koncur/test-hub.yaml
         retention-days: 3
 
     - name: Cleanup Kind cluster


### PR DESCRIPTION
Resolves #255 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Maven setup is now enabled by default for Kantra and Tackle Hub testing.
  * Maven configuration and environment setup run consistently across supported operating systems.
  * Testing can now target a specified Koncur version or branch.
  * CI workflows use the resolved Kantra image consistently during validation.

* **Tests**
  * Shared testing workflows now provide more consistent execution across operating systems and Maven configurations.
  * Workflow-based validation now defaults to Maven-enabled testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->